### PR TITLE
test: deflake parallel crash-recovery heartbeat timeout

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -544,7 +544,7 @@ class TestParallelOrchestratorPhase1:
             tasklist="docs/tasklist.md",
             merge_strategy="cherry-pick",
             worktree_cleanup="always",
-            parallel_heartbeat_ttl=0.1,
+            parallel_heartbeat_ttl=300,
             loc_threshold=1000,
         )
         po = ParallelOrchestrator(orch, eval_manager_factory=_eval_factory(True))


### PR DESCRIPTION
## Summary
- make `test_e2e_crash_recovery_then_run_succeeds` deterministic
- increase `parallel_heartbeat_ttl` in that test from `0.1` to `300`

## Why
The test uses a thread-based worker runner that does not emit heartbeats. With `parallel_heartbeat_ttl=0.1`, slower CI runners can mark the in-flight task as timed out, causing intermittent failure even when crash-recovery behavior is correct.

## Validation
- `pytest -q tests/test_parallel.py::TestParallelOrchestratorPhase1::test_e2e_crash_recovery_then_run_succeeds`
- `pytest -q tests/test_parallel.py`
- repeated targeted run loop: 80/80 passed
