### PR TITLE
docs: add branding assets and wire logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# millstone
+<h1><img src="docs/assets/logo-wordmark.svg" alt="millstone logo" width="760" /></h1>
 [![CI](https://github.com/wittekin/millstone/actions/workflows/ci.yml/badge.svg)](https://github.com/wittekin/millstone/actions/workflows/ci.yml)
 [![Quality](https://github.com/wittekin/millstone/actions/workflows/quality.yml/badge.svg)](https://github.com/wittekin/millstone/actions/workflows/quality.yml)
 [![Coverage](https://codecov.io/gh/wittekin/millstone/branch/main/graph/badge.svg)](https://codecov.io/gh/wittekin/millstone)
 [![Docs](https://github.com/wittekin/millstone/actions/workflows/docs.yml/badge.svg)](https://github.com/wittekin/millstone/actions/workflows/docs.yml)
 [![Release](https://github.com/wittekin/millstone/actions/workflows/release.yml/badge.svg)](https://github.com/wittekin/millstone/actions/workflows/release.yml)
-[![PyPI version](https://img.shields.io/pypi/v/millstone.svg)](https://pypi.org/project/millstone/)
-[![Python versions](https://img.shields.io/pypi/pyversions/millstone.svg)](https://pypi.org/project/millstone/)
-[![License](https://img.shields.io/pypi/l/millstone.svg)](https://github.com/wittekin/millstone/blob/main/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/millstone.svg?cacheSeconds=300)](https://pypi.org/project/millstone/)
+[![Python versions](https://img.shields.io/pypi/pyversions/millstone.svg?cacheSeconds=300)](https://pypi.org/project/millstone/)
+[![License](https://img.shields.io/pypi/l/millstone.svg?cacheSeconds=300)](https://github.com/wittekin/millstone/blob/main/LICENSE)
 
 Coding agents produce dramatically better results when they plan before they code, and when their output is reviewed by a second agent — ideally from a different model provider. The catch: manually running that cycle (design → review → revise → approve → plan → review → revise → implement → review → revise → commit) across multiple agents is extremely time-consuming.
 

--- a/docs/assets/logo-icon.svg
+++ b/docs/assets/logo-icon.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="512"
+  height="512"
+  viewBox="36 36 440 440"
+  role="img"
+  aria-label="millstone logo icon"
+>
+  <defs>
+    <mask id="millstoneCuts">
+      <rect width="512" height="512" fill="#fff" />
+      <g transform="translate(256 256)" fill="#000">
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(45)" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(90)" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(135)" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(180)" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(225)" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(270)" />
+        <rect x="-19" y="-246" width="38" height="84" rx="3" ry="3" transform="rotate(315)" />
+      </g>
+    </mask>
+  </defs>
+  <path
+    fill="#98C379"
+    fill-rule="evenodd"
+    mask="url(#millstoneCuts)"
+    d="M256 36A220 220 0 1 1 256 476A220 220 0 1 1 256 36ZM256 116A140 140 0 1 0 256 396A140 140 0 1 0 256 116Z"
+  />
+</svg>

--- a/docs/assets/logo-wordmark.svg
+++ b/docs/assets/logo-wordmark.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="1420"
+  height="340"
+  viewBox="0 0 1420 340"
+  role="img"
+  aria-label="millstone wordmark"
+>
+  <defs>
+    <mask id="millstoneCuts" maskUnits="userSpaceOnUse" x="0" y="0" width="360" height="340">
+      <rect width="360" height="340" fill="#fff" />
+      <g transform="translate(170 156)" fill="#000">
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(45)" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(90)" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(135)" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(180)" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(225)" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(270)" />
+        <rect x="-16" y="-190" width="32" height="68" rx="3" ry="3" transform="rotate(315)" />
+      </g>
+    </mask>
+  </defs>
+
+  <path
+    fill="#98C379"
+    fill-rule="evenodd"
+    mask="url(#millstoneCuts)"
+    d="M170 0A156 156 0 1 1 170 312A156 156 0 1 1 170 0ZM170 57A99 99 0 1 0 170 255A99 99 0 1 0 170 57Z"
+  />
+
+  <text
+    x="340"
+    y="312"
+    font-family="JetBrains Mono, Fira Code, Cascadia Code, SFMono-Regular, Menlo, Consolas, monospace"
+    font-size="132"
+    font-weight="700"
+    letter-spacing="2"
+  >
+    <tspan fill="#E06C75">m</tspan><tspan fill="#98C379">illstone</tspan>
+  </text>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ repo_name: wittekin/millstone
 
 theme:
   name: material
+  logo: assets/logo-icon.svg
+  favicon: assets/logo-icon.svg
   features:
     - navigation.instant
     - navigation.sections


### PR DESCRIPTION
## Summary
- add wordmark + icon branding assets
- update README header to use wordmark
- wire MkDocs logo/favicon to `docs/assets/logo-icon.svg`
- add badge cache tuning query params to reduce stale PyPI badge lag

## Scope
Docs/branding only. No version bump, tag, or release changes.
