### PR TITLE
docs: make quickstart design-first and tasklist-explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,28 @@ cd /path/to/your/project
 # @docs/prompts/design.md   (design + plan a new feature)
 ```
 
-Manual run to complete one task from your tasklist:
+Design-first quickstart (recommended):
 
 ```bash
+# 1) Draft + review a design
+millstone --design "Add retry logic to API client"
+
+# 2) Turn that design into tasklist items
+DESIGN_DOC=$(ls -t .millstone/designs/*.md | head -n 1)
+millstone --plan "$DESIGN_DOC"
+
+# 3) Execute the first planned task
 millstone -n 1
 ```
+
+Fast smoke test (no tasklist required):
+
+```bash
+millstone --task "add retry logic to API client"
+```
+
+`millstone` / `millstone -n 1` read from the configured tasklist path (default: `.millstone/tasklist.md`).
+Use `--task` when you want a one-off run without tasklist setup.
 
 ## Highlights
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,17 +35,34 @@ pip install -e .[release]
 
 ## Basic usage
 
-Run tasks from `.millstone/tasklist.md`:
+Design-first flow (recommended):
+
+```bash
+# 1) Draft + review a design
+millstone --design "Add retry logic"
+
+# 2) Turn that design into a tasklist
+DESIGN_DOC=$(ls -t .millstone/designs/*.md | head -n 1)
+millstone --plan "$DESIGN_DOC"
+
+# 3) Execute the first planned task
+millstone -n 1
+```
+
+Fast smoke test (no tasklist required):
+
+```bash
+millstone --task "add retry logic"
+```
+
+Run from tasklist directly:
 
 ```bash
 millstone
 ```
 
-Run a one-off task:
-
-```bash
-millstone --task "add retry logic"
-```
+`millstone` and `millstone -n 1` read tasks from the configured tasklist path
+(default: `.millstone/tasklist.md`). Use `--task` for one-off execution when no tasklist exists yet.
 
 Explore all options:
 


### PR DESCRIPTION
## Summary
- make quickstart explicitly design-first (`--design` -> `--plan` -> `-n 1`)
- add a no-tasklist smoke-test path (`--task`)
- clearly state that `millstone` / `-n 1` require a tasklist path (default `.millstone/tasklist.md`)

## Why
Current quickstart can fail for first-time users because it assumes tasklist/config setup without saying so. This clarifies the shortest successful path while preserving the one-off shortcut.
