### PR TITLE
docs: simplify design-first quickstart and mention --cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,10 @@ pytest --cov=. --cov-report=term-missing
 
 # Run the orchestrator (requires at least one supported CLI installed:
 # claude, codex, gemini, or opencode)
-millstone                           # Process tasks from .millstone.artifacts.tasklist.md
+millstone                           # Process tasks from .millstone/tasklist.md
 millstone --task "description"      # Single direct task
+millstone --migrate-tasklist backlog.md  # Convert a local backlog to tasklist format
+millstone --deliver "objective"     # Design -> plan -> execute (skip analyze)
 millstone --dry-run                 # Preview prompts without invoking agent
 millstone --cli codex               # Use Codex CLI instead of Claude
 
@@ -156,7 +158,7 @@ the full open-issue set for the configured project/team/repo. Use `[millstone.ar
 in `.millstone/config.toml` to restrict execution without changing provider options.
 
 **When to use local vs remote**:
-- **Local `.millstone.artifacts.tasklist.md`** — solo work, personal projects, explicit ordering.
+- **Local `.millstone/tasklist.md`** — solo work, personal projects, explicit ordering.
 - **Remote provider + filter** — team boards in Jira/Linear/GitHub where the backlog is shared.
 
 **Quick examples**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [0.3.5] - 2026-03-06
+
+- Added `--deliver "OBJECTIVE"` for a discoverable design -> plan -> execute flow that skips analyze.
+- Added `--migrate-tasklist PATH` to convert local backlog files into canonical tasklist format.
+- Simplified Quick Start documentation around five common user entry points.
+- Clarified Quick Start prerequisites: install/authenticate at least one supported coding agent CLI.
+- Fixed documentation command references to the default `.millstone/tasklist.md` path.
+
+## [0.3.4] - 2026-03-05
+
+- Updated branding assets and README header rendering.
+- Improved docs and release/badge wiring reliability.
+
 ## [0.3.3] - 2026-03-03
 
 Initial public release.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Coding agents produce dramatically better results when they plan before they cod
 
 ## Quick Start
 
+Before installing `millstone`, install and authenticate at least one supported coding agent CLI.
+See [Supported Agents](docs/cli-providers/index.md).
+
 ```bash
 # 1) Install
 pipx install millstone
@@ -29,36 +32,34 @@ cd /path/to/your/project
 # @docs/prompts/design.md   (design + plan a new feature)
 ```
 
-Design-first quickstart (recommended):
+Pick the path that matches your intent:
 
 ```bash
-# 1) Draft + review a design
-millstone --design "Add retry logic to API client"
-
-# 2) Plan tasks from that design
-# Design files default to .millstone/designs/<kebab-case-opportunity>.md
-millstone --plan .millstone/designs/add-retry-logic-to-api-client.md
-
-# 3) Execute the first planned task
-millstone -n 1
-```
-
-Fast smoke test (no tasklist required):
-
-```bash
+# 1) One task now (no tasklist setup required)
 millstone --task "add retry logic to API client"
-```
 
-`millstone` / `millstone -n 1` read from the configured tasklist path (default: `.millstone/tasklist.md`).
-Use `--task` when you want a one-off run without tasklist setup.
+# 2) Existing local backlog -> migrate once, then execute
+millstone --migrate-tasklist backlog.md
+millstone
 
-Closest single-command flow:
+# 3) Design -> plan -> execute one objective (skips analyze)
+millstone --deliver "Add retry logic to API client"
 
-```bash
+# 4) New app / fresh repo
+millstone --init
+millstone --deliver "Build a CLI app for release note generation"
+
+# 5) Full autonomous loop on an existing project
 millstone --cycle
 ```
 
-`--cycle` runs `analyze -> design -> plan -> build -> eval` when no pending tasks exist.
+For a series of human-written goals with no analyze step, use roadmap + cycle:
+
+```bash
+millstone --cycle --roadmap docs/roadmap.md
+```
+
+`millstone` reads from `.millstone/tasklist.md` by default.
 
 ## Highlights
 
@@ -79,12 +80,15 @@ millstone --cycle
 | Execute next tasks from tasklist | `millstone` |
 | Limit to one task | `millstone -n 1` |
 | Run custom one-off task | `millstone --task "..."` |
+| Migrate an existing local backlog to tasklist format | `millstone --migrate-tasklist backlog.md` |
+| Design, plan, and execute one scoped objective | `millstone --deliver "..."` |
 | Claude code as author, codex as reviewer, one task, max of 6 write/review cycles task | `millstone --cli claude --cli-reviewer codex -n 1 --max-cycles 6` |
 | Run 4 tasks in parallel (worktree mode) | `millstone --worktrees --concurrency 4` |
 | Dry-run prompt flow without invoking agents | `millstone --dry-run` |
 | Scan codebase for opportunities | `millstone --analyze` |
 | Generate a design doc | `millstone --design "Add caching layer"` |
 | Turn design into atomic tasks | `millstone --plan .millstone/designs/add-caching-layer.md` |
+| Execute roadmap goals without analyze | `millstone --cycle --roadmap docs/roadmap.md` |
 | Run autonomous cycle end-to-end | `millstone --cycle` |
 
 ## How It Works

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,24 +35,31 @@ pip install -e .[release]
 
 ## Basic usage
 
-Design-first flow (recommended):
+Choose the workflow that matches what you have:
 
 ```bash
-# 1) Draft + review a design
-millstone --design "Add retry logic"
+# 1) One task now (no tasklist setup)
+millstone --task "add retry logic"
 
-# 2) Plan tasks from that design
-# Design files default to .millstone/designs/<kebab-case-opportunity>.md
-millstone --plan .millstone/designs/add-retry-logic.md
+# 2) Existing local backlog file -> migrate once
+millstone --migrate-tasklist backlog.md
+millstone
 
-# 3) Execute the first planned task
-millstone -n 1
+# 3) Design -> plan -> execute one objective (skips analyze)
+millstone --deliver "Add retry logic"
+
+# 4) New app / fresh repo
+millstone --init
+millstone --deliver "Build a CLI app for release note generation"
+
+# 5) Full autonomous improvement loop
+millstone --cycle
 ```
 
-Fast smoke test (no tasklist required):
+Roadmap-driven flow (no analyze step):
 
 ```bash
-millstone --task "add retry logic"
+millstone --cycle --roadmap docs/roadmap.md
 ```
 
 Run from tasklist directly:
@@ -62,15 +69,7 @@ millstone
 ```
 
 `millstone` and `millstone -n 1` read tasks from the configured tasklist path
-(default: `.millstone/tasklist.md`). Use `--task` for one-off execution when no tasklist exists yet.
-
-Closest single-command flow:
-
-```bash
-millstone --cycle
-```
-
-When no pending tasks exist, `--cycle` runs `analyze -> design -> plan -> build -> eval`.
+(default: `.millstone/tasklist.md`).
 
 Explore all options:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.3.4"
+version = "0.3.5"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -145,6 +145,110 @@ def _configure_python_logging_for_verbosity(log_verbosity: str) -> None:
     root_logger.addHandler(handler)
 
 
+def _ensure_tasklist_file(tasklist_path: Path) -> None:
+    """Create a minimal tasklist file if it does not exist."""
+    if tasklist_path.exists():
+        return
+    tasklist_path.parent.mkdir(parents=True, exist_ok=True)
+    tasklist_path.write_text("# Tasklist\n")
+
+
+def _extract_backlog_items(backlog_text: str) -> list[tuple[str, str]]:
+    """Extract backlog items from markdown/plain text into (status, task_text)."""
+    items: list[tuple[str, str]] = []
+    in_code_block = False
+
+    # Prefer explicit task-like syntax when present.
+    has_structured_tasks = bool(
+        re.search(
+            r"^\s*(?:[-*]\s+\[[ xX]\]\s+|[-*]\s+|\d+[.)]\s+|\[[ xX]\]\s+|TODO[:\-]\s+)",
+            backlog_text,
+            re.MULTILINE,
+        )
+    )
+
+    for raw_line in backlog_text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        if stripped.startswith("#") or stripped.startswith("<!--"):
+            continue
+
+        # Checked/unchecked markdown checkbox list items.
+        checkbox_match = re.match(r"^\s*[-*]\s+\[([ xX])\]\s+(.+?)\s*$", raw_line)
+        if checkbox_match:
+            status = "x" if checkbox_match.group(1).strip().lower() == "x" else " "
+            items.append((status, checkbox_match.group(2).strip()))
+            continue
+
+        # Bare checkbox without markdown bullet.
+        bare_checkbox_match = re.match(r"^\s*\[([ xX])\]\s+(.+?)\s*$", raw_line)
+        if bare_checkbox_match:
+            status = "x" if bare_checkbox_match.group(1).strip().lower() == "x" else " "
+            items.append((status, bare_checkbox_match.group(2).strip()))
+            continue
+
+        # Bullet lists.
+        bullet_match = re.match(r"^\s*[-*]\s+(.+?)\s*$", raw_line)
+        if bullet_match:
+            items.append((" ", bullet_match.group(1).strip()))
+            continue
+
+        # Numbered lists.
+        numbered_match = re.match(r"^\s*\d+[.)]\s+(.+?)\s*$", raw_line)
+        if numbered_match:
+            items.append((" ", numbered_match.group(1).strip()))
+            continue
+
+        # TODO-prefixed lines.
+        todo_match = re.match(r"^\s*TODO[:\-]\s+(.+?)\s*$", raw_line, re.IGNORECASE)
+        if todo_match:
+            items.append((" ", todo_match.group(1).strip()))
+            continue
+
+        # Plain-text migration fallback for line-oriented backlogs.
+        if not has_structured_tasks:
+            items.append((" ", stripped))
+
+    return items
+
+
+def _migrate_local_backlog(source_path: Path, output_path: Path) -> dict[str, Any]:
+    """Convert a local backlog file into canonical markdown tasklist format."""
+    if not source_path.exists():
+        raise FileNotFoundError(f"Backlog file not found: {source_path}")
+
+    backlog_text = source_path.read_text()
+    items = _extract_backlog_items(backlog_text)
+    if not items:
+        raise ValueError(
+            "No actionable backlog items found. Use bullet/numbered lines or one task per line."
+        )
+
+    output_lines = ["# Tasklist", ""]
+    for status, task_text in items:
+        output_lines.append(f"- [{status}] {task_text}")
+    output_lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(output_lines))
+
+    completed_count = sum(1 for status, _ in items if status == "x")
+    pending_count = len(items) - completed_count
+    return {
+        "source_path": str(source_path),
+        "output_path": str(output_path),
+        "task_count": len(items),
+        "pending_count": pending_count,
+        "completed_count": completed_count,
+    }
+
+
 class _NoopLock:
     """Minimal lock protocol implementation for best-effort worker state writes."""
 
@@ -3016,12 +3120,25 @@ def main():
         "then iterates through build-review cycles until approval or max cycles reached.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
+Common workflows:
+  1) One task now
+     %(prog)s --task "add login page"
+  2) Existing backlog (local)
+     %(prog)s --migrate-tasklist backlog.md
+     %(prog)s
+  3) Design -> plan -> execute (skip analyze)
+     %(prog)s --deliver "Add retry logic to API client"
+  4) New project / fresh app
+     %(prog)s --init
+     %(prog)s --deliver "Build a CLI app for ..."
+  5) Full autonomous improvement loop
+     %(prog)s --cycle
+
 Examples:
   %(prog)s                           Run using default tasklist (.millstone/tasklist.md)
-  %(prog)s --task "add login page"   Execute a single task directly
-  %(prog)s --tasklist TODO.md      Use custom tasklist file
+  %(prog)s --tasklist TODO.md        Use custom tasklist file
   %(prog)s --max-cycles 5            Allow up to 5 build-review iterations
-  %(prog)s --dry-run                 Preview prompts without invoking claude
+  %(prog)s --dry-run                 Preview prompts without invoking the configured CLI
 
 Configuration:
   Settings can be stored in .millstone/config.toml. CLI flags override config file values.
@@ -3095,6 +3212,15 @@ Remote backlog scoping (Jira / Linear / GitHub):
         help="Path to the markdown tasklist file containing tasks. The builder picks "
         "the first unchecked task (- [ ]) and marks it complete (- [x]) when done. "
         f"Ignored if --task is provided. (default: {config['tasklist']})",
+    )
+    parser.add_argument(
+        "--migrate-tasklist",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Convert a local backlog file into canonical tasklist format and write it to "
+        "--tasklist (default: .millstone/tasklist.md). Accepts markdown checklists, bullet "
+        "lists, numbered lists, TODO-prefixed lines, or one-task-per-line text files.",
     )
     parser.add_argument(
         "--roadmap",
@@ -3527,6 +3653,16 @@ Remote backlog scoping (Jira / Linear / GitHub):
         "Example: --plan designs/add-retry-logic.md",
     )
     parser.add_argument(
+        "--deliver",
+        type=str,
+        default=None,
+        metavar="OBJECTIVE",
+        help="Run design -> optional design review -> plan -> execute for one objective. "
+        "This explicitly skips analyze, creates --tasklist if missing for file-backed tasklists, "
+        "and halts if pending tasks already exist to avoid mixing scopes. "
+        "Example: --deliver 'Add retry logic to API client'",
+    )
+    parser.add_argument(
         "--cycle",
         action="store_true",
         help="Run the full autonomous cycle: analyze → design → plan → build → eval. "
@@ -3581,6 +3717,14 @@ Remote backlog scoping (Jira / Linear / GitHub):
     if args.issues and not args.analyze:
         parser.error("--issues requires --analyze. Use: --analyze --issues PATH")
 
+    # Validate --deliver exclusivity with other outer-loop entrypoints
+    if args.deliver and (
+        args.analyze or args.design or args.plan or args.cycle or args.review_design
+    ):
+        parser.error(
+            "--deliver cannot be combined with --analyze, --design, --review-design, --plan, or --cycle."
+        )
+
     # Preserve config values not exposed as CLI args (CLI overrides config)
     prompts_dir = args.prompts_dir if args.prompts_dir else config.get("prompts_dir")
     eval_scripts = config.get("eval_scripts", [])
@@ -3589,6 +3733,27 @@ Remote backlog scoping (Jira / Linear / GitHub):
     _configure_python_logging_for_verbosity(log_verbosity)
     # Compute effective log_diff_mode: --full-diff flag overrides config
     log_diff_mode = "full" if args.full_diff else config.get("log_diff_mode", "summary")
+
+    # Handle --migrate-tasklist: normalize a local backlog into markdown checklist format
+    if args.migrate_tasklist:
+        try:
+            source_path = Path(args.migrate_tasklist)
+            output_path = Path(args.tasklist)
+            result = _migrate_local_backlog(source_path=source_path, output_path=output_path)
+            print("Tasklist migration complete:")
+            print(f"  Source: {result['source_path']}")
+            print(f"  Output: {result['output_path']}")
+            print(
+                f"  Tasks: {result['task_count']} total "
+                f"({result['pending_count']} pending, {result['completed_count']} completed)"
+            )
+            print()
+            print("Next step:")
+            print("  millstone")
+            sys.exit(0)
+        except Exception as e:
+            print(f"Error migrating tasklist: {e}", file=sys.stderr)
+            sys.exit(1)
 
     # Handle --clear-sessions: clear stored session IDs and exit
     if args.clear_sessions:
@@ -3802,6 +3967,78 @@ Remote backlog scoping (Jira / Linear / GitHub):
             sys.exit(0 if result.get("success", False) else 1)
         except Exception as e:
             print(f"Error running plan: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Handle --deliver: design -> review(optional) -> plan -> execute
+    if args.deliver:
+        review_designs = config.get("review_designs", True)
+        using_remote_provider = config.get("tasklist_provider", "file") != "file"
+        if not using_remote_provider:
+            _ensure_tasklist_file(Path.cwd() / args.tasklist)
+
+        orchestrator = Orchestrator(
+            max_cycles=args.max_cycles,
+            loc_threshold=args.loc_threshold,
+            tasklist=args.tasklist,
+            max_tasks=args.max_tasks,
+            dry_run=args.dry_run,
+            prompts_dir=prompts_dir,
+            compact_threshold=args.compact_threshold,
+            eval_on_commit=args.eval_on_commit,
+            auto_rollback=args.auto_rollback,
+            eval_scripts=eval_scripts,
+            eval_on_task=args.eval_on_task,
+            skip_eval=args.skip_eval,
+            review_designs=review_designs,
+            profile=config.get("profile", "dev_implementation"),
+            cli=args.cli,
+            cli_builder=args.cli_builder,
+            cli_reviewer=args.cli_reviewer,
+            cli_sanity=args.cli_sanity,
+            cli_analyzer=args.cli_analyzer,
+            log_verbosity=log_verbosity,
+            log_diff_mode=log_diff_mode,
+        )
+        try:
+            orchestrator.preflight_checks()
+
+            if orchestrator.has_remaining_tasks():
+                print(
+                    "Error: --deliver requires an empty pending tasklist so the new objective "
+                    "does not mix with existing backlog tasks.",
+                    file=sys.stderr,
+                )
+                print(
+                    "Run `millstone` to finish existing tasks first, or point `--tasklist` "
+                    "to a fresh file for this objective.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            design_result = orchestrator.run_design(opportunity=args.deliver)
+            if not design_result.get("success", False):
+                sys.exit(1)
+
+            design_ref = design_result.get("design_file") or design_result.get("design_id")
+            if not design_ref:
+                print("Error: design did not return a usable design reference.", file=sys.stderr)
+                sys.exit(1)
+
+            if review_designs:
+                review_result = orchestrator.review_design(str(design_ref))
+                if not review_result.get("approved", False):
+                    sys.exit(1)
+
+            plan_result = orchestrator.run_plan(design_path=str(design_ref))
+            if not plan_result.get("success", False):
+                sys.exit(1)
+
+            sys.exit(orchestrator.run())
+        except PreflightError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error running deliver flow: {e}", file=sys.stderr)
             sys.exit(1)
 
     # Handle --cycle: run full autonomous cycle and exit

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -391,6 +391,52 @@ class TestCapabilityProfileCliPlumbing:
         _, kwargs = mock_init.call_args
         assert kwargs["max_cycles"] == 7
 
+    def test_deliver_branch_passes_profile_and_max_cycles(self, temp_repo):
+        """--deliver passes profile and max_cycles into Orchestrator."""
+        from millstone import orchestrate
+
+        with patch(
+            "sys.argv",
+            [
+                "orchestrate.py",
+                "--deliver",
+                "Add retries",
+                "--max-cycles",
+                "7",
+                "--tasklist",
+                ".millstone/deliver.md",
+            ],
+        ):
+            with patch.object(orchestrate.Orchestrator, "__init__", return_value=None) as mock_init:
+                with patch.object(orchestrate.Orchestrator, "preflight_checks"):
+                    with patch.object(
+                        orchestrate.Orchestrator, "has_remaining_tasks", return_value=False
+                    ):
+                        with patch.object(
+                            orchestrate.Orchestrator,
+                            "run_design",
+                            return_value={"success": True, "design_file": "designs/add-retries.md"},
+                        ):
+                            with patch.object(
+                                orchestrate.Orchestrator,
+                                "review_design",
+                                return_value={"approved": True},
+                            ):
+                                with patch.object(
+                                    orchestrate.Orchestrator,
+                                    "run_plan",
+                                    return_value={"success": True, "tasks_added": 1},
+                                ):
+                                    with patch.object(
+                                        orchestrate.Orchestrator, "run", return_value=0
+                                    ):
+                                        with pytest.raises(SystemExit):
+                                            orchestrate.main()
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["profile"] == "dev_implementation"
+        assert kwargs["max_cycles"] == 7
+
 
 class TestOuterLoopManagerMaxCyclesPlumbing:
     """Tests that Orchestrator forwards max_cycles to OuterLoopManager."""
@@ -10864,6 +10910,207 @@ class TestPlanCLI:
 
                 # Verify the tasklist argument was passed to run_plan
                 mock_plan.assert_called_once()
+
+
+class TestMigrateTasklistCLI:
+    """Tests for --migrate-tasklist CLI flag."""
+
+    def test_migrate_tasklist_converts_bullets(self, temp_repo):
+        """Migrates markdown bullets into tasklist checkbox format."""
+        from millstone import orchestrate
+
+        backlog = temp_repo / "backlog.md"
+        backlog.write_text("# Backlog\n\n- Add retry logic\n- Improve docs\n")
+        output = temp_repo / ".millstone" / "migrated.md"
+
+        with patch(
+            "sys.argv",
+            [
+                "orchestrate.py",
+                "--migrate-tasklist",
+                str(backlog),
+                "--tasklist",
+                str(output.relative_to(temp_repo)),
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                orchestrate.main()
+
+        assert exc_info.value.code == 0
+        content = output.read_text()
+        assert content.startswith("# Tasklist")
+        assert "- [ ] Add retry logic" in content
+        assert "- [ ] Improve docs" in content
+
+    def test_migrate_tasklist_preserves_checked_items(self, temp_repo):
+        """Checked markdown tasks remain checked in migrated tasklist."""
+        from millstone import orchestrate
+
+        backlog = temp_repo / "backlog.md"
+        backlog.write_text("- [x] Completed task\n- [ ] Pending task\n")
+        output = temp_repo / ".millstone" / "migrated.md"
+
+        with patch(
+            "sys.argv",
+            [
+                "orchestrate.py",
+                "--migrate-tasklist",
+                str(backlog),
+                "--tasklist",
+                str(output.relative_to(temp_repo)),
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                orchestrate.main()
+
+        assert exc_info.value.code == 0
+        content = output.read_text()
+        assert "- [x] Completed task" in content
+        assert "- [ ] Pending task" in content
+
+    def test_migrate_tasklist_exits_1_when_no_items_found(self, temp_repo):
+        """Migration fails with exit code 1 when no actionable items can be parsed."""
+        from millstone import orchestrate
+
+        backlog = temp_repo / "backlog.md"
+        backlog.write_text("# Backlog\n\n## Notes\n\n")
+
+        with patch("sys.argv", ["orchestrate.py", "--migrate-tasklist", str(backlog)]):
+            with pytest.raises(SystemExit) as exc_info:
+                orchestrate.main()
+
+        assert exc_info.value.code == 1
+
+
+class TestDeliverCLI:
+    """Tests for --deliver CLI flow."""
+
+    def test_deliver_runs_design_plan_execute(self, temp_repo):
+        """--deliver executes design, review, plan, then run."""
+        from millstone import orchestrate
+
+        with patch(
+            "sys.argv",
+            [
+                "orchestrate.py",
+                "--deliver",
+                "Add retry logic",
+                "--tasklist",
+                ".millstone/deliver.md",
+            ],
+        ):
+            with patch.object(Orchestrator, "preflight_checks"):
+                with patch.object(Orchestrator, "has_remaining_tasks", return_value=False):
+                    with patch.object(Orchestrator, "run_design") as mock_design:
+                        with patch.object(Orchestrator, "review_design") as mock_review:
+                            with patch.object(Orchestrator, "run_plan") as mock_plan:
+                                with patch.object(Orchestrator, "run", return_value=0) as mock_run:
+                                    mock_design.return_value = {
+                                        "success": True,
+                                        "design_file": "designs/add-retry-logic.md",
+                                    }
+                                    mock_review.return_value = {"approved": True}
+                                    mock_plan.return_value = {"success": True, "tasks_added": 3}
+
+                                    with pytest.raises(SystemExit) as exc_info:
+                                        orchestrate.main()
+
+        assert exc_info.value.code == 0
+        mock_design.assert_called_once_with(opportunity="Add retry logic")
+        mock_review.assert_called_once_with("designs/add-retry-logic.md")
+        mock_plan.assert_called_once_with(design_path="designs/add-retry-logic.md")
+        mock_run.assert_called_once()
+
+    def test_deliver_skips_design_review_when_disabled_in_config(self, temp_repo):
+        """When review_designs=false, --deliver skips review_design call."""
+        from millstone import orchestrate
+
+        config_dir = temp_repo / ".millstone"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.toml").write_text("review_designs = false\n")
+
+        with patch(
+            "sys.argv",
+            ["orchestrate.py", "--deliver", "Add retry logic", "--tasklist", ".millstone/new.md"],
+        ):
+            with patch.object(Orchestrator, "preflight_checks"):
+                with patch.object(Orchestrator, "has_remaining_tasks", return_value=False):
+                    with patch.object(Orchestrator, "run_design") as mock_design:
+                        with patch.object(Orchestrator, "review_design") as mock_review:
+                            with patch.object(Orchestrator, "run_plan") as mock_plan:
+                                with patch.object(Orchestrator, "run", return_value=0):
+                                    mock_design.return_value = {
+                                        "success": True,
+                                        "design_file": "designs/add-retry-logic.md",
+                                    }
+                                    mock_plan.return_value = {"success": True, "tasks_added": 1}
+
+                                    with pytest.raises(SystemExit) as exc_info:
+                                        orchestrate.main()
+
+        assert exc_info.value.code == 0
+        mock_review.assert_not_called()
+
+    def test_deliver_exits_1_when_pending_tasks_exist(self, temp_repo):
+        """--deliver halts when tasklist already has pending tasks."""
+        from millstone import orchestrate
+
+        with patch("sys.argv", ["orchestrate.py", "--deliver", "Add retry logic"]):
+            with patch.object(Orchestrator, "preflight_checks"):
+                with patch.object(Orchestrator, "has_remaining_tasks", return_value=True):
+                    with patch.object(Orchestrator, "run_design") as mock_design:
+                        with pytest.raises(SystemExit) as exc_info:
+                            orchestrate.main()
+
+        assert exc_info.value.code == 1
+        mock_design.assert_not_called()
+
+    def test_deliver_creates_missing_tasklist_for_file_provider(self, temp_repo):
+        """--deliver creates tasklist file when target path is missing."""
+        from millstone import orchestrate
+
+        target = temp_repo / ".millstone" / "new-tasklist.md"
+        assert not target.exists()
+
+        with patch(
+            "sys.argv",
+            [
+                "orchestrate.py",
+                "--deliver",
+                "Add retry logic",
+                "--tasklist",
+                ".millstone/new-tasklist.md",
+            ],
+        ):
+            with patch.object(Orchestrator, "preflight_checks"):
+                with patch.object(Orchestrator, "has_remaining_tasks", return_value=False):
+                    with patch.object(Orchestrator, "run_design") as mock_design:
+                        with patch.object(Orchestrator, "review_design") as mock_review:
+                            with patch.object(Orchestrator, "run_plan") as mock_plan:
+                                with patch.object(Orchestrator, "run", return_value=0):
+                                    mock_design.return_value = {
+                                        "success": True,
+                                        "design_file": "designs/add-retry-logic.md",
+                                    }
+                                    mock_review.return_value = {"approved": True}
+                                    mock_plan.return_value = {"success": True, "tasks_added": 1}
+
+                                    with pytest.raises(SystemExit) as exc_info:
+                                        orchestrate.main()
+
+        assert exc_info.value.code == 0
+        assert target.exists()
+        assert target.read_text().startswith("# Tasklist")
+
+    def test_deliver_cannot_be_combined_with_cycle(self, temp_repo):
+        """--deliver with --cycle is an argument error."""
+        from millstone import orchestrate
+
+        with patch("sys.argv", ["orchestrate.py", "--deliver", "Add retry logic", "--cycle"]):
+            with pytest.raises(SystemExit) as exc_info:
+                orchestrate.main()
+
+        assert exc_info.value.code == 2
 
 
 class TestSelectOpportunity:


### PR DESCRIPTION
## Summary
- remove the design-doc env-var step from quickstart
- show explicit default design path usage (`.millstone/designs/...`)
- document `--cycle` as the closest built-in single-command flow

## Why
Quickstart should stay simple while still encouraging a design-first workflow.
