### PR TITLE
fix: compact MCP list_tasks/list_designs — drop descriptions to prevent 80KB agent responses

### DIFF
--- a/src/millstone/artifact_providers/mcp.py
+++ b/src/millstone/artifact_providers/mcp.py
@@ -229,7 +229,7 @@ class MCPTasklistProvider(TasklistProviderBase):
         cb = self._require_callback()
         prompt = (
             f"Use the {self._mcp_server} MCP to get the task with ID '{task_id}'. "
-            f"Output ONLY a JSON object with fields: id, title, status, context, criteria."
+            f"Output ONLY a JSON object with fields: id, title, status, context, criteria, tests, risk."
         )
         response = cb(prompt)
         try:
@@ -245,6 +245,8 @@ class MCPTasklistProvider(TasklistProviderBase):
             status=status,
             context=item.get("context"),
             criteria=item.get("criteria"),
+            tests=item.get("tests"),
+            risk=item.get("risk"),
         )
 
     def get_snapshot(self) -> str:
@@ -259,9 +261,9 @@ class MCPTasklistProvider(TasklistProviderBase):
         The status checkbox is always derived from ``t.status`` (not from raw),
         so the snapshot reflects the true current state.
 
-        The full-block format is required because _validate_generated_tasks()
-        calls _parse_task_metadata() on new-task text extracted from the snapshot
-        diff and validates Tests/Risk/Criteria/Context fields.
+        For MCP providers, _validate_generated_tasks() fetches full task details
+        via get_task() instead of parsing snapshot text, so compact snapshots
+        (title-only) are fine for validation purposes.
         """
         tasks = self.list_tasks()
         # Only capture the baseline on the first call; subsequent calls (e.g.

--- a/src/millstone/loops/outer.py
+++ b/src/millstone/loops/outer.py
@@ -1739,12 +1739,23 @@ When addressing similar areas, try a different approach than what caused the reg
             "violations": violations,
         }
 
-    def _validate_generated_tasks(self, old_content: str, new_content: str) -> dict:
+    def _validate_generated_tasks(
+        self,
+        old_content: str,
+        new_content: str,
+        *,
+        new_task_ids: list[str] | None = None,
+    ) -> dict:
         """Validate all newly generated tasks against constraints.
 
         Args:
             old_content: Tasklist content before planning.
             new_content: Tasklist content after planning.
+            new_task_ids: Optional list of task IDs created by this planning pass.
+                When provided and the tasklist provider is an MCP provider, full
+                details are fetched via get_task() instead of parsing snapshot text.
+                Callers must compute this immediately after the planning agent
+                returns to avoid including tasks added by external actors.
 
         Returns:
             Dict with validation results:
@@ -1752,6 +1763,10 @@ When addressing similar areas, try a different approach than what caused the reg
             - tasks: List of dicts with task metadata and validation results
             - violations_summary: Human-readable summary of all violations
         """
+        # For MCP providers, fetch full task details instead of parsing compact snapshot text
+        if new_task_ids is not None and self._is_mcp_provider():
+            return self._validate_generated_tasks_mcp(new_task_ids)
+
         new_tasks = self._extract_new_tasks(old_content, new_content)
 
         results = []
@@ -1772,6 +1787,73 @@ When addressing similar areas, try a different approach than what caused the reg
                 title = metadata["title"] or metadata["description"][:50]
                 for v in validation["violations"]:
                     all_violations.append(f"- **{title}**: {v}")
+
+        return {
+            "valid": len(all_violations) == 0,
+            "tasks": results,
+            "violations_summary": "\n".join(all_violations) if all_violations else "",
+        }
+
+    def _is_mcp_provider(self) -> bool:
+        """Check if the current tasklist provider is an MCP provider."""
+        try:
+            from millstone.artifact_providers.mcp import MCPTasklistProvider
+
+            return isinstance(self.tasklist_provider, MCPTasklistProvider)
+        except ImportError:
+            return False
+
+    def _validate_generated_tasks_mcp(self, new_task_ids: list[str]) -> dict:
+        """Validate newly generated MCP tasks by fetching full details via get_task().
+
+        MCP list_tasks() returns compact data (id/title/status only) to avoid large
+        responses. This method fetches full task details for each new task so that
+        metadata validation (tests, risk, criteria, context) works correctly.
+
+        Args:
+            new_task_ids: Pre-computed list of task IDs created by the current
+                planning pass. Callers must compute this immediately after the
+                planning agent returns to avoid picking up tasks added by
+                external actors on shared MCP backlogs.
+        """
+        from millstone.artifact_providers.mcp import MCPTasklistProvider
+
+        provider: MCPTasklistProvider = self.tasklist_provider  # type: ignore[assignment]
+
+        results = []
+        all_violations = []
+
+        for task_id in new_task_ids:
+            task = provider.get_task(task_id)
+            if task is None:
+                all_violations.append(
+                    f"- **{task_id}**: failed to fetch task details via get_task()"
+                )
+                continue
+
+            metadata: dict[str, Any] = {
+                "title": task.title,
+                "description": task.title,
+                "est_loc": None,
+                "tests": task.tests,
+                "risk": task.risk,
+                "criteria": task.criteria,
+                "context": task.context,
+                "context_file": None,
+                "raw": task.raw or task.title,
+            }
+
+            validation = self._validate_task(metadata)
+            results.append(
+                {
+                    "metadata": metadata,
+                    "validation": validation,
+                }
+            )
+
+            if not validation["valid"]:
+                for v in validation["violations"]:
+                    all_violations.append(f"- **{task.title}**: {v}")
 
         return {
             "valid": len(all_violations) == 0,
@@ -1883,8 +1965,6 @@ When addressing similar areas, try a different approach than what caused the reg
                 log_callback("plan_failed", design_path=design_path, reason="tasklist_not_found")
             print(f"\n=== Planning Failed ===\n{error_msg}")
             return {"success": False, "tasks_added": 0, "error": error_msg}
-        tasks_before_ids = {t.task_id for t in self.tasklist_provider.list_tasks()}
-
         # Callbacks are validated and injected by the run_plan() entry point.
 
         # State tracking for the loop
@@ -1893,17 +1973,31 @@ When addressing similar areas, try a different approach than what caused the reg
             "validation": {"valid": False, "violations_summary": ""},
         }
 
+        # Accumulate task IDs created by this planning session's agent calls.
+        # We snapshot IDs immediately before and after each agent call, so
+        # external tasks added on shared MCP backlogs between calls are excluded.
+        planner_task_ids: set[str] = set()
+
         tasklist_placeholders = self.tasklist_provider.get_prompt_placeholders()
+
+        def _snapshot_and_run(prompt: str) -> None:
+            """Snapshot task IDs, run agent, then diff to find newly created IDs."""
+            _invalidate_tasklist_cache(self.tasklist_provider)
+            ids_before_call = {t.task_id for t in self.tasklist_provider.list_tasks()}
+            run_agent_callback(prompt)
+            _invalidate_tasklist_cache(self.tasklist_provider)
+            ids_after_call = {t.task_id for t in self.tasklist_provider.list_tasks()}
+            planner_task_ids.update(ids_after_call - ids_before_call)
+            # Also remove any IDs the agent deleted during a split/fix
+            planner_task_ids.intersection_update(ids_after_call)
 
         def produce_tasks(feedback: str | None = None) -> list[str]:
             """Inner producer that handles both initial generation and refinement."""
             if feedback:
-                # Get tasks the agent added so far (by ID diff) for the fix prompt.
+                # Get tasks the agent added so far for the fix prompt.
                 # No restore here — agent edits the existing tasks in place.
                 current_tasks = [
-                    t
-                    for t in self.tasklist_provider.list_tasks()
-                    if t.task_id not in tasks_before_ids
+                    t for t in self.tasklist_provider.list_tasks() if t.task_id in planner_task_ids
                 ]
                 current_added = "\n".join(f"- [ ] {t.raw or t.title}" for t in current_tasks)
 
@@ -1914,8 +2008,7 @@ When addressing similar areas, try a different approach than what caused the reg
                 fix_prompt = apply_provider_placeholders(fix_prompt, tasklist_placeholders)
                 # Backward-compat: custom --prompts-dir templates may still use {{TASKLIST_PATH}}
                 fix_prompt = fix_prompt.replace("{{TASKLIST_PATH}}", self.tasklist)
-                run_agent_callback(fix_prompt)
-                _invalidate_tasklist_cache(self.tasklist_provider)
+                _snapshot_and_run(fix_prompt)
             else:
                 # Initial generation
                 plan_prompt = load_prompt_callback("plan_prompt.md")
@@ -1926,12 +2019,14 @@ When addressing similar areas, try a different approach than what caused the reg
                 plan_prompt = apply_provider_placeholders(plan_prompt, tasklist_placeholders)
                 # Backward-compat: custom --prompts-dir templates may still use {{TASKLIST_PATH}}
                 plan_prompt = plan_prompt.replace("{{TASKLIST_PATH}}", self.tasklist)
-                run_agent_callback(plan_prompt)
-                _invalidate_tasklist_cache(self.tasklist_provider)
+                _snapshot_and_run(plan_prompt)
 
             # Mechanical validation loop (Atomizer)
             new_content = self.tasklist_provider.get_snapshot()
-            validation = self._validate_generated_tasks(original_tasklist_content, new_content)
+            new_task_ids = list(planner_task_ids)
+            validation = self._validate_generated_tasks(
+                original_tasklist_content, new_content, new_task_ids=new_task_ids
+            )
 
             max_split_attempts = self.task_constraints.get("max_split_attempts", 2)
             split_attempt = 0
@@ -1953,16 +2048,18 @@ When addressing similar areas, try a different approach than what caused the reg
                 # Backward-compat: custom --prompts-dir templates may still use {{TASKLIST_PATH}}
                 split_prompt = split_prompt.replace("{{TASKLIST_PATH}}", self.tasklist)
 
-                run_agent_callback(split_prompt)
-                _invalidate_tasklist_cache(self.tasklist_provider)
+                _snapshot_and_run(split_prompt)
+                # planner_task_ids already updated by _snapshot_and_run
+                new_task_ids = list(planner_task_ids)
                 validation = self._validate_generated_tasks(
                     original_tasklist_content,
                     self.tasklist_provider.get_snapshot(),
+                    new_task_ids=new_task_ids,
                 )
 
             state["validation"] = validation
             tasks_after = self.tasklist_provider.list_tasks()
-            return [t.title for t in tasks_after if t.task_id not in tasks_before_ids]
+            return [t.title for t in tasks_after if t.task_id in planner_task_ids]
 
         def review_tasks(tasks: list[str]) -> dict:
             added_content = "\n".join(f"- [ ] {t}" for t in tasks)

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -2228,10 +2228,18 @@ class Orchestrator:
         self._outer_loop_manager.task_constraints = self.task_constraints
         return self._outer_loop_manager._validate_task(task_metadata)
 
-    def _validate_generated_tasks(self, old_content: str, new_content: str) -> dict:
+    def _validate_generated_tasks(
+        self,
+        old_content: str,
+        new_content: str,
+        *,
+        new_task_ids: list[str] | None = None,
+    ) -> dict:
         # Delegates to OuterLoopManager (syncs constraints first)
         self._outer_loop_manager.task_constraints = self.task_constraints
-        return self._outer_loop_manager._validate_generated_tasks(old_content, new_content)
+        return self._outer_loop_manager._validate_generated_tasks(
+            old_content, new_content, new_task_ids=new_task_ids
+        )
 
     def run_plan(self, design_path: str) -> dict:
         # Delegates to OuterLoopManager

--- a/tests/test_mcp_providers.py
+++ b/tests/test_mcp_providers.py
@@ -1562,3 +1562,298 @@ class TestMCPFencedJsonResponses:
         provider = MCPOpportunityProvider("github")
         provider.set_agent_callback(lambda _prompt: "```json\nnot-json\n```")
         assert provider.get_opportunity("o1") is None
+
+
+# ---------------------------------------------------------------------------
+# MCP plan validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCPPlanValidation:
+    """Test that _validate_generated_tasks fetches full details for MCP providers."""
+
+    def _make_manager(self, mcp_provider, tmp_path):
+        """Create an OuterLoopManager with an MCP tasklist provider."""
+        from millstone.loops.outer import OuterLoopManager
+
+        work_dir = tmp_path / ".millstone"
+        work_dir.mkdir()
+        return OuterLoopManager(
+            work_dir=work_dir,
+            repo_dir=tmp_path,
+            tasklist=".millstone/tasklist.md",
+            task_constraints={
+                "max_loc": 200,
+                "require_tests": True,
+                "require_criteria": True,
+                "require_risk": True,
+                "require_context": True,
+            },
+            tasklist_provider=mcp_provider,
+        )
+
+    def test_mcp_task_with_metadata_passes_validation(self, tmp_path):
+        """MCP task with all metadata passes validation when fetched via get_task()."""
+        provider = MCPTasklistProvider("github")
+
+        # get_task returns full details including metadata
+        get_response = json.dumps(
+            {
+                "id": "new-1",
+                "title": "Add caching layer",
+                "status": "todo",
+                "tests": "test_caching.py",
+                "risk": "low",
+                "criteria": "Cache hit rate >90%",
+                "context": "src/caching/",
+            }
+        )
+
+        def agent_callback(prompt):
+            if "get the task with ID" in prompt:
+                return get_response
+            return "[]"
+
+        provider.set_agent_callback(agent_callback)
+        manager = self._make_manager(provider, tmp_path)
+
+        # Pass pre-computed new task IDs (as callers now do after planning)
+        result = manager._validate_generated_tasks("", "", new_task_ids=["new-1"])
+
+        assert result["valid"] is True
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["validation"]["valid"] is True
+        assert result["tasks"][0]["metadata"]["tests"] == "test_caching.py"
+        assert result["tasks"][0]["metadata"]["risk"] == "low"
+        assert result["tasks"][0]["metadata"]["criteria"] == "Cache hit rate >90%"
+        assert result["tasks"][0]["metadata"]["context"] == "src/caching/"
+
+    def test_mcp_task_without_metadata_fails_validation(self, tmp_path):
+        """MCP task missing metadata fails validation even though snapshot is compact."""
+        provider = MCPTasklistProvider("github")
+
+        # get_task returns task with NO metadata
+        get_response = json.dumps(
+            {
+                "id": "new-1",
+                "title": "Add caching layer",
+                "status": "todo",
+            }
+        )
+
+        def agent_callback(prompt):
+            if "get the task with ID" in prompt:
+                return get_response
+            return "[]"
+
+        provider.set_agent_callback(agent_callback)
+        manager = self._make_manager(provider, tmp_path)
+
+        result = manager._validate_generated_tasks("", "", new_task_ids=["new-1"])
+
+        assert result["valid"] is False
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["validation"]["valid"] is False
+        violations = result["tasks"][0]["validation"]["violations"]
+        assert len(violations) >= 3  # tests, criteria, risk, context
+
+    def test_file_provider_unchanged_without_new_task_ids(self, tmp_path):
+        """File provider uses text-based validation when new_task_ids is not passed."""
+        from millstone.artifacts.tasklist import TasklistManager
+        from millstone.loops.outer import OuterLoopManager
+
+        work_dir = tmp_path / ".millstone"
+        work_dir.mkdir()
+        tm = TasklistManager(str(tmp_path / ".millstone" / "tasklist.md"))
+        manager = OuterLoopManager(
+            work_dir=work_dir,
+            repo_dir=tmp_path,
+            tasklist=".millstone/tasklist.md",
+            task_constraints={
+                "max_loc": 200,
+                "require_tests": True,
+                "require_criteria": True,
+                "require_risk": True,
+                "require_context": True,
+            },
+            parse_task_metadata_callback=tm._parse_task_metadata,
+        )
+
+        old_content = "- [ ] Old task"
+        new_content = """- [ ] Old task
+- [ ] **Good task**: Description
+  - Est. LoC: 50
+  - Tests: test.py
+  - Risk: low
+  - Criteria: All pass
+  - Context: src/"""
+
+        # No new_task_ids → file-provider text-based path
+        result = manager._validate_generated_tasks(old_content, new_content)
+        assert result["valid"] is True
+        assert len(result["tasks"]) == 1
+
+    def test_mcp_get_task_includes_tests_and_risk_fields(self):
+        """get_task() prompt requests and parses tests and risk fields."""
+        provider = MCPTasklistProvider("github")
+        response = json.dumps(
+            {
+                "id": "t1",
+                "title": "Task 1",
+                "status": "todo",
+                "tests": "test_foo.py",
+                "risk": "high",
+                "context": "src/foo/",
+                "criteria": "All green",
+            }
+        )
+        provider.set_agent_callback(lambda _prompt: response)
+        task = provider.get_task("t1")
+        assert task is not None
+        assert task.tests == "test_foo.py"
+        assert task.risk == "high"
+        assert task.context == "src/foo/"
+        assert task.criteria == "All green"
+
+    def test_mcp_get_task_returns_none_fails_validation(self, tmp_path):
+        """When get_task() returns None for a new task, validation must fail."""
+        provider = MCPTasklistProvider("github")
+
+        def agent_callback(prompt):
+            if "get the task with ID" in prompt:
+                return "not valid json {{{}"
+            return "[]"
+
+        provider.set_agent_callback(agent_callback)
+        manager = self._make_manager(provider, tmp_path)
+
+        result = manager._validate_generated_tasks("", "", new_task_ids=["new-1"])
+
+        assert result["valid"] is False
+        assert "failed to fetch task details" in result["violations_summary"]
+
+    def test_external_mcp_tasks_excluded_from_planner_output(self, tmp_path):
+        """Tasks created by external actors between agent calls are not
+        attributed to the planner and are excluded from validation/results.
+
+        Scenario: planner creates plan-1 (missing metadata → validation fails).
+        Between the after-snapshot of the initial plan call and the
+        before-snapshot of the split-fix call, an external actor creates ext-1
+        on the shared MCP backlog. After split fixes plan-1 and the reviewer
+        approves, ext-1 must NOT appear in the planner's output.
+        """
+        from millstone.artifacts.models import Design, DesignStatus
+        from millstone.loops.outer import OuterLoopManager
+
+        provider = MCPTasklistProvider("github")
+
+        # Mutable shared backlog — simulates a real MCP backend.
+        task_store: list[dict] = []
+        list_tasks_count = 0
+
+        def provider_callback(prompt):
+            """Handles list_tasks / get_task calls from the MCP provider."""
+            nonlocal list_tasks_count
+            if "get the task with ID" in prompt:
+                for t in task_store:
+                    if t["id"] in prompt:
+                        return json.dumps(t)
+                return "invalid"
+            # All other provider calls are list_tasks.
+            list_tasks_count += 1
+            # Inject ext-1 on the 4th list_tasks call — this is the split
+            # agent's before-snapshot.  ext-1 then appears in both the
+            # before and after snapshots of the split call, so the per-call
+            # diff excludes it (correctly attributing only plan-1 to the
+            # planner).  Under the old set-difference approach,
+            # current - tasks_before_ids would have included ext-1.
+            if list_tasks_count == 4 and not any(t["id"] == "ext-1" for t in task_store):
+                task_store.append(
+                    {
+                        "id": "ext-1",
+                        "title": "External task",
+                        "status": "todo",
+                        "tests": "e.py",
+                        "risk": "low",
+                        "criteria": "done",
+                        "context": "src/",
+                    }
+                )
+            return json.dumps(task_store)
+
+        provider.set_agent_callback(provider_callback)
+
+        # Set up design
+        designs_dir = tmp_path / ".millstone" / "designs"
+        designs_dir.mkdir(parents=True)
+        design_file = designs_dir / "test-design.md"
+        design_file.write_text("# Design: Test\nSome design content")
+
+        mock_design_provider = MagicMock()
+        mock_design_provider.get_design.return_value = Design(
+            design_id="test-design",
+            title="Test",
+            body="Some design content",
+            status=DesignStatus.approved,
+        )
+
+        manager = OuterLoopManager(
+            work_dir=tmp_path / ".millstone",
+            repo_dir=tmp_path,
+            tasklist=".millstone/tasklist.md",
+            task_constraints={
+                "max_loc": 200,
+                "require_tests": True,
+                "require_criteria": True,
+                "require_risk": True,
+                "require_context": True,
+                "max_split_attempts": 1,
+            },
+            tasklist_provider=provider,
+            design_provider=mock_design_provider,
+        )
+
+        def run_agent(prompt):
+            if "plan_prompt" in prompt:
+                # Initial plan agent — creates plan-1 (missing metadata)
+                task_store.append(
+                    {
+                        "id": "plan-1",
+                        "title": "Planner task",
+                        "status": "todo",
+                    }
+                )
+                return "Created plan-1"
+            if "task_split_prompt" in prompt:
+                # Split-fix agent — adds metadata to plan-1
+                for i, t in enumerate(task_store):
+                    if t["id"] == "plan-1":
+                        task_store[i] = {
+                            "id": "plan-1",
+                            "title": "Planner task",
+                            "status": "todo",
+                            "tests": "t.py",
+                            "risk": "low",
+                            "criteria": "done",
+                            "context": "src/",
+                        }
+                return "Fixed plan-1"
+            if "plan_review_prompt" in prompt:
+                return '{"verdict": "APPROVED", "score": 10}'
+            return "noop"
+
+        provider._task_cache = None
+
+        result = manager._run_plan_impl(
+            design_path=str(design_file),
+            load_prompt_callback=lambda name: (
+                f"prompt_name: {name}\n{{{{DESIGN_CONTENT}}}}\n{{{{TASKLIST_CONTENT}}}}\n{{{{MAX_LOC}}}}\n{{{{VIOLATIONS}}}}\n{{{{PROPOSED_PLAN}}}}"
+            ),
+            run_agent_callback=run_agent,
+        )
+
+        assert result["success"] is True
+        # Only plan-1 should be counted (created by planner).
+        # ext-1 was injected between agent calls by an external actor and
+        # must NOT be attributed to this planning pass.
+        assert result["tasks_added"] == 1


### PR DESCRIPTION
## Problem

`MCPTasklistProvider.list_tasks` requested `description: "full stored task body text"` for ALL tasks in all states. With 20+ issues (including 19 closed), the agent produced ~80KB of JSON and redirected to a temp file instead of returning inline output — crashing `has_remaining_tasks()`.

Additionally, `_validate_generated_tasks()` in `outer.py` compared task snapshot text to find metadata (Tests, Risk, Criteria, Context). Since MCP list_tasks no longer returns descriptions, validation would see empty metadata for every new task and produce false violations.

## Fixes

**Commit 1** — compact `list_tasks` / `list_designs`:
- `list_tasks` prompt requests only `id`, `title`, `status`
- `list_designs` prompt drops `body` (use `get_design(id)` when body needed)
- Both prompts add "do not write to a file" as belt-and-suspenders

**Commit 2** — MCP-aware plan validation (closes #37):
- `_validate_generated_tasks()` detects MCP tasklist provider
- For each new task, calls `get_task(task_id)` to fetch full details
- Validates metadata from MCP-stored fields (not from snapshot text)
- File provider behavior unchanged

## Test plan
- [x] `pytest tests/ -x -q` passes (1778 tests, +6 new)
- [x] `tests/test_mcp_providers.py` — all pass with updated expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)