### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternatives

### DIFF
--- a/src/millstone/loops/outer.py
+++ b/src/millstone/loops/outer.py
@@ -243,7 +243,7 @@ class OuterLoopManager:
             return EffectRecord(
                 intent=intent,
                 status=EffectStatus.skipped,
-                timestamp=datetime.utcnow().isoformat() + "Z",
+                timestamp=datetime.now(timezone.utc).isoformat(),
             )
         return self._effect_gate.apply(intent)
 

--- a/src/millstone/policy/effects.py
+++ b/src/millstone/policy/effects.py
@@ -57,14 +57,14 @@ class NoOpEffectProvider:
         return EffectRecord(
             intent=intent,
             status=EffectStatus.skipped,
-            timestamp=datetime.datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(),
         )
 
     def observe(self, intent: EffectIntent) -> EffectRecord:
         return EffectRecord(
             intent=intent,
             status=EffectStatus.skipped,
-            timestamp=datetime.datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(),
         )
 
     def health_check(self) -> bool:
@@ -120,7 +120,7 @@ class EffectPolicyGate:
             return EffectRecord(
                 intent=intent,
                 status=EffectStatus.denied,
-                timestamp=datetime.datetime.utcnow().isoformat() + "Z",
+                timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                 error="Effect denied by approval hook",
             )
 

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -2313,8 +2313,8 @@ class Orchestrator:
             created_at = entry.get("created_at", "")
             if created_at:
                 try:
-                    created_dt = datetime.fromisoformat(created_at.rstrip("Z"))
-                    age_hours = (datetime.utcnow() - created_dt).total_seconds() / 3600
+                    created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+                    age_hours = (datetime.now(timezone.utc) - created_dt).total_seconds() / 3600
                     if age_hours > 24:
                         print(
                             f"[staging] WARNING: pending MCP sync for {sync_type} is "


### PR DESCRIPTION
## Summary

Replaces all `datetime.utcnow()` calls (deprecated in Python 3.12+) with `datetime.now(timezone.utc)` / `datetime.datetime.now(datetime.timezone.utc)`. Also fixes the downstream `fromisoformat` consumer in `orchestrator.py` that was stripping `Z` naively — now uses `.replace("Z", "+00:00")` for Python 3.10 compatibility before comparing timezone-aware datetimes.

## Test plan
- [x] All 1827 tests pass, 0 `utcnow` deprecation warnings in `pytest` output
- [x] Pre-commit hooks (ruff, mypy, vulture, pytest) all pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)