### PR TITLE
fix: use exit code to determine lint error count in --eval

### DIFF
--- a/src/millstone/artifacts/eval_manager.py
+++ b/src/millstone/artifacts/eval_manager.py
@@ -769,8 +769,12 @@ class EvalManager:
                     timeout=60,
                     cwd=self.repo_dir,
                 )
-                # For custom commands, count output lines as issues
-                error_count = len([line for line in result.stdout.split("\n") if line.strip()])
+                # Exit code 0 means the linter found no issues.
+                # For non-zero exit, count non-empty output lines as a proxy for issue count.
+                if result.returncode == 0:
+                    error_count = 0
+                else:
+                    error_count = len([line for line in result.stdout.split("\n") if line.strip()])
             else:
                 result = subprocess.run(
                     ["ruff", "check", ".", "--output-format=json"],


### PR DESCRIPTION
## Summary

`millstone --eval` was reporting `lint: 0.99 (errors=1)` on a clean codebase. Root cause: `_run_lint()` was counting all non-empty output lines as errors when a configured `lint_cmd` was used. `ruff check .` (the default Python project command) outputs `"All checks passed!"` on success — one non-empty line counted as 1 error.

Fix: check exit code first. Exit code 0 → errors=0. Non-zero → count output lines as before.

## Test plan
- [x] `millstone --eval` now shows `lint: 1.00 (errors=0)` on clean code
- [x] All eval-related tests pass (141 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)