### PR TITLE
fix: graceful error for --split-task with remote MCP providers

### DIFF
--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -4325,6 +4325,17 @@ Remote backlog scoping (Jira / Linear / GitHub):
 
     # Handle --split-task: analyze a task and suggest subtasks
     if args.split_task is not None:
+        using_remote_provider = config.get("tasklist_provider", "file") != "file"
+        if using_remote_provider:
+            print(
+                "Task splitting is not supported for remote providers.",
+                file=sys.stderr,
+            )
+            print(
+                "Use your provider's native interface to manage tasks.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         orchestrator = Orchestrator(
             tasklist=args.tasklist,
             dry_run=False,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -16277,6 +16277,26 @@ class TestSplitTask:
         finally:
             orch.cleanup()
 
+    def test_split_task_remote_provider_exits_with_error(self, temp_repo, monkeypatch, capsys):
+        """--split-task with remote provider prints error and exits 1."""
+        import sys
+
+        from millstone.runtime.orchestrator import main
+
+        # Configure remote provider
+        config_dir = temp_repo / ".millstone"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.toml").write_text('tasklist_provider = "mcp"\n')
+
+        monkeypatch.setattr(sys, "argv", ["millstone", "--split-task", "1"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "not supported for remote providers" in captured.err
+
 
 class TestProgressEstimation:
     """Tests for progress estimation functionality."""


### PR DESCRIPTION
## Summary

`millstone --split-task N` was crashing with `"Tasklist not found: .millstone/tasklist.md"` when a remote MCP provider (GitHub Issues, Linear) is configured. Task splitting reads from the local file which doesn't exist for remote backends.

Now prints a clear message and exits 1: `"Task splitting is not supported for remote providers. Use your provider's native interface to manage tasks."`

## Test plan
- [x] `millstone --split-task 1` with GitHub Issues backend shows the graceful error
- [x] 1839 tests pass (+1 new)
- [x] Pre-commit hooks pass

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)