### PR TITLE
chore: release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [0.4.2] - 2026-03-07
+
+### Fixed
+- Show MCP provider name and labels in startup header instead of local file path (#56).
+- `--status` now shows live open task count from remote provider (#57).
+- `--research` mode now closes remote tasks via MCP after completing research output (#58).
+- `tasklist_prompt.md` now explicitly forbids builder from committing during implementation (#60).
+- Orchestrator detects when builder commits early and uses committed diff for review (#60).
+
 ## [0.4.1] - 2026-03-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.4.1"
+version = "0.4.2"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release 0.4.2 — MCP ergonomics fixes from #61.

## Changes
- Show MCP provider name and labels in startup header instead of local file path (#56)
- `--status` now shows live open task count from remote provider (#57)
- `--research` mode now closes remote tasks via MCP after completing research output (#58)
- `tasklist_prompt.md` now explicitly forbids builder from committing during implementation (#60)
- Orchestrator detects when builder commits early and uses committed diff for review (#60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)