### PR TITLE
Release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-04-06
+
+### Changed
+- Sanity checks are now advisory instead of blocking. Implementation sanity flags are injected into the reviewer prompt as context rather than halting the session. Review sanity flags for unparseable reviews are surfaced in builder feedback and treated as REQUEST_CHANGES.
+
 ## [0.6.4] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-04-02
+
+### Fixed
+- MCP-backed task completion finalization now only performs a direct provider-side status update when the active profile permits `C2_remote_bounded` transactional effects, avoiding false task failures under the default `C1_local_write` profile while preserving explicit remote close-out for C2-capable runs.
+- Corrected MCP provider documentation to reflect the actual default profile behavior for direct provider-side remote writes.
+
 ## [0.6.3] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-02
+
+### Fixed
+- Single-task scope validation now accepts compacted tasklists that move the selected completed item into the `Completed` summary section, avoiding false scope violations after compaction.
+- Inner-loop `--continue` now preserves selected-task identity so resumed builder/reviewer work cannot drift to a different task after a mid-task halt.
+- Successful MCP-backed task runs now explicitly mark the selected remote task done after commit, instead of relying only on the builder prompt to do it.
+- Automatic compaction on tracked tasklists now finalizes its own tasklist rewrite immediately, preventing compaction-only changes from leaking into the next task's diff, review, or commit.
+
 ## [0.6.2] - 2026-03-31
 
 ### Fixed

--- a/docs/providers/mcp.md
+++ b/docs/providers/mcp.md
@@ -144,7 +144,9 @@ Any MCP server your agent supports works — the `mcp_server` value is passed th
 
 ## Effect policy
 
-All MCP operations are classified as `EffectClass.transactional` (C2). Under the default `DEV_IMPLEMENTATION` profile these are permitted. If you have a stricter policy configured (e.g. `C1_LOCAL_WRITE` only), MCP operations will raise `CapabilityViolation` — update `.millstone/policy.toml` to allow `C2_REMOTE_BOUNDED` effects.
+Millstone-classified MCP write operations are `EffectClass.transactional` (`C2_remote_bounded`). The default `dev_implementation` profile is `C1_local_write`, so direct provider writes that millstone issues itself are not permitted unless you configure a `C2_remote_bounded` profile with `transactional` effects allowlisted.
+
+In the default profile, prompt-driven MCP actions performed by the coding agent can still run because the agent is executing those tool calls from the rendered prompt, not through millstone's direct provider-effect path. Orchestrator-driven follow-up writes, such as explicit post-commit remote task completion, are skipped unless the active profile allows those transactional effects.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.2"
+version = "0.6.3"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.3"
+version = "0.6.4"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.4"
+version = "0.6.5"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/millstone/artifact_providers/file.py
+++ b/src/millstone/artifact_providers/file.py
@@ -676,8 +676,12 @@ class FileTasklistProvider(TasklistProviderBase):
                 "`- [ ]` pending, `- [x]` complete. Select the FIRST unchecked task."
             ),
             "TASKLIST_COMPLETE_INSTRUCTIONS": (
-                f"Mark exactly this one task complete by changing its `- [ ]` to "
-                f"`- [x]` in `{self.path}` and stop. Do not modify any other tasks."
+                f"Mark exactly this one task complete in `{self.path}` and stop. "
+                "Normally, change its `- [ ]` to `- [x]`. "
+                "If the file has a `Completed` summary section instead of listing older "
+                "finished tasks individually, you may instead remove the selected task from "
+                "the pending list and update only that `Completed` summary. Do not modify "
+                "any other pending tasks."
             ),
             "TASKLIST_REWRITE_INSTRUCTIONS": (
                 f"Write the entire compacted content back to `{self.path}`, "

--- a/src/millstone/artifacts/tasklist.py
+++ b/src/millstone/artifacts/tasklist.py
@@ -414,6 +414,10 @@ class TasklistManager:
             tasks.append((checked.lower() == "x", task_text.strip()))
         return tasks
 
+    def _has_completed_summary_section(self, content: str) -> bool:
+        """Return True when the tasklist already uses a compacted completed summary."""
+        return bool(re.search(r"^#{2,6}\s+Completed\b", content, re.MULTILINE | re.IGNORECASE))
+
     def validate_single_task_completion(
         self,
         original_content: str,
@@ -430,7 +434,25 @@ class TasklistManager:
         if not original_tasks or not new_tasks:
             return True, ""
 
+        first_unchecked = next(
+            (i for i, (checked, _) in enumerate(original_tasks) if not checked),
+            None,
+        )
+
         if len(new_tasks) < len(original_tasks):
+            if (
+                first_unchecked is not None
+                and len(new_tasks) == len(original_tasks) - 1
+                and (
+                    self._has_completed_summary_section(original_content)
+                    or self._has_completed_summary_section(new_content)
+                )
+            ):
+                expected_tasks = (
+                    original_tasks[:first_unchecked] + original_tasks[first_unchecked + 1 :]
+                )
+                if new_tasks == expected_tasks:
+                    return True, ""
             return (
                 False,
                 f"Task count decreased: {len(original_tasks)} -> {len(new_tasks)}. Deleting tasks is not allowed.",
@@ -457,10 +479,6 @@ class TasklistManager:
                 f"Multiple tasks were marked complete ({len(checkoffs)}).",
             )
 
-        first_unchecked = next(
-            (i for i, (checked, _) in enumerate(original_tasks) if not checked),
-            None,
-        )
         if first_unchecked is None:
             return False, "No unchecked tasks remained, but a task was marked complete."
 

--- a/src/millstone/loops/inner.py
+++ b/src/millstone/loops/inner.py
@@ -104,11 +104,11 @@ class InnerLoopManager:
         git_diff: str,
         load_prompt_callback: Callable[[str], str],
         run_agent_callback: Callable[..., str],
-    ) -> bool:
+    ) -> str | None:
         """Sanity check implementation before review.
 
-        Uses structured output to get OK/HALT signal from the sanity check agent.
-        Falls back to file-based STOP.md detection for compatibility.
+        Uses structured output to get OK/FLAG signal from the sanity check agent.
+        Flags are passed to the reviewer as advisory context rather than halting.
 
         Args:
             agent_output: Output from the builder agent.
@@ -118,7 +118,7 @@ class InnerLoopManager:
             run_agent_callback: Callback to invoke the LLM agent.
 
         Returns:
-            True if sanity check passed, False if halted.
+            Flag reason string if concerns were raised, None if OK.
         """
         prompt = load_prompt_callback("sanity_check_impl.md")
         prompt = prompt.replace("{{ORCHESTRATOR_DIR}}", str(self.work_dir))
@@ -136,33 +136,31 @@ class InnerLoopManager:
         # Try structured parsing first
         result = parse_sanity_result(output)
         if result is not None and result.should_halt:
-            # Write STOP.md for consistency with existing mechanism
-            stop_file = self.work_dir / "STOP.md"
-            reason = result.reason or "Sanity check halted (no reason provided)"
-            stop_file.write_text(f"Implementation sanity check failed:\n\n{reason}\n")
+            flag = result.reason or "Sanity check flagged concerns (no detail provided)"
             print()
-            print("=== STOPPED ===")
-            print("Reason:")
-            print(reason)
-            return False
+            print("=== SANITY FLAG ===")
+            print("Flagged for reviewer:")
+            print(flag)
+            return flag
 
-        # Fallback: check for file-based signal (compatibility)
-        if self.check_stop():
-            return False
+        # Fallback: check for file-based signal (legacy/external tooling)
+        stop_flag = self._consume_stop_file()
+        if stop_flag is not None:
+            return stop_flag
 
         print("Implementation sanity check: OK")
-        return True
+        return None
 
     def sanity_check_review(
         self,
         review_output: str,
         load_prompt_callback: Callable[[str], str],
         run_agent_callback: Callable[..., str],
-    ) -> bool:
+    ) -> str | None:
         """Sanity check review before passing back to builder.
 
-        Uses structured output to get OK/HALT signal from the sanity check agent.
-        Falls back to file-based STOP.md detection for compatibility.
+        Uses structured output to get OK/FLAG signal from the sanity check agent.
+        Flags are logged as warnings rather than halting the session.
 
         Args:
             review_output: Output from the reviewer agent.
@@ -170,7 +168,7 @@ class InnerLoopManager:
             run_agent_callback: Callback to invoke the LLM agent.
 
         Returns:
-            True if sanity check passed, False if halted.
+            Flag reason string if concerns were raised, None if OK.
         """
         prompt = load_prompt_callback("sanity_check_review.md")
         prompt = prompt.replace("{{ORCHESTRATOR_DIR}}", str(self.work_dir))
@@ -186,22 +184,35 @@ class InnerLoopManager:
         # Try structured parsing first
         result = parse_sanity_result(output)
         if result is not None and result.should_halt:
-            # Write STOP.md for consistency with existing mechanism
-            stop_file = self.work_dir / "STOP.md"
-            reason = result.reason or "Sanity check halted (no reason provided)"
-            stop_file.write_text(f"Review sanity check failed:\n\n{reason}\n")
+            flag = result.reason or "Sanity check flagged concerns (no detail provided)"
             print()
-            print("=== STOPPED ===")
-            print("Reason:")
-            print(reason)
-            return False
+            print("=== SANITY FLAG (review) ===")
+            print("Warning:")
+            print(flag)
+            return flag
 
-        # Fallback: check for file-based signal (compatibility)
-        if self.check_stop():
-            return False
+        # Fallback: check for file-based signal (legacy/external tooling)
+        stop_flag = self._consume_stop_file()
+        if stop_flag is not None:
+            return stop_flag
 
         print("Review sanity check: OK")
-        return True
+        return None
+
+    def _consume_stop_file(self) -> str | None:
+        """Read and remove STOP.md if it exists.
+
+        Returns the file contents as a flag string, or None.
+        """
+        stop_file = self.work_dir / "STOP.md"
+        if stop_file.exists():
+            reason = stop_file.read_text()
+            stop_file.unlink()
+            print()
+            print("=== SANITY FLAG (from STOP.md) ===")
+            print(reason)
+            return reason
+        return None
 
     # =========================================================================
     # Mechanical checks

--- a/src/millstone/prompts/review_prompt.md
+++ b/src/millstone/prompts/review_prompt.md
@@ -13,6 +13,7 @@ Builder Output:
 Git Diff:
 {{GIT_DIFF}}
 </context>
+{{SANITY_FLAGS}}
 
 <process>
 1. Use the selected task scope provided later in this prompt as the authoritative scope.

--- a/src/millstone/prompts/sanity_check_impl.md
+++ b/src/millstone/prompts/sanity_check_impl.md
@@ -3,13 +3,13 @@
 Check whether the author's work is reasonable enough to send to review.
 Do not do a full review.
 
-Halt only for serious problems:
+Flag only for serious problems:
 - incoherent or unrelated output
 - obvious failure loops or catastrophic errors
 - destructive or unsafe changes
 - no meaningful work when the task clearly required changes
 
-Do not halt for normal bugs, incompleteness, style issues, or tangential but relevant work.
+Do not flag for normal bugs, incompleteness, style issues, or tangential but relevant work.
 
 Author output:
 {{AGENT_OUTPUT}}
@@ -29,5 +29,5 @@ Return JSON only:
 or
 
 ```json
-{"status": "HALT", "reason": "why human intervention is required"}
+{"status": "HALT", "reason": "concise description of the concern for the reviewer"}
 ```

--- a/src/millstone/prompts/sanity_check_review.md
+++ b/src/millstone/prompts/sanity_check_review.md
@@ -3,13 +3,13 @@
 Check whether the review feedback is coherent and safe enough to send back to the author.
 Do not re-review the underlying work.
 
-Halt only for serious problems:
+Flag only for serious problems:
 - incoherent or unrelated feedback
 - dangerous instructions
 - contradictions that make the feedback impossible to act on
 - clear mismatch with the changed work
 
-Do not halt for:
+Do not flag for:
 - minor factual inaccuracies such as line lengths, character counts, or other small numeric mistakes
 - stylistic disagreement
 - incomplete analysis
@@ -28,5 +28,5 @@ Return JSON only:
 or
 
 ```json
-{"status": "HALT", "reason": "why human intervention is required"}
+{"status": "HALT", "reason": "concise description of the concern"}
 ```

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -55,7 +55,7 @@ from millstone.loops.inner import InnerLoopManager
 from millstone.loops.outer import OuterLoopManager
 from millstone.loops.registry_adapter import LoopRegistryAdapter
 from millstone.policy.capability import CapabilityPolicyGate, CapabilityTier
-from millstone.policy.effects import EffectIntent, EffectPolicyGate, NoOpEffectProvider
+from millstone.policy.effects import EffectClass, EffectIntent, EffectPolicyGate, NoOpEffectProvider
 from millstone.policy.schemas import (
     ReviewDecision,
     ReviewStatus,
@@ -2423,6 +2423,16 @@ class Orchestrator:
         ):
             provider.set_agent_callback(lambda p, **k: self.run_agent(p, role="author", **k))
 
+    def _can_finalize_remote_task_completion(self) -> tuple[bool, str | None]:
+        """Check whether the active profile may perform direct remote task completion."""
+        try:
+            self._capability_gate.assert_permitted(CapabilityTier.C2_REMOTE_BOUNDED)
+        except Exception as exc:
+            return False, str(exc)
+        if EffectClass.transactional not in self.profile.permitted_effect_classes:
+            return False, "Effect class transactional is not in permitted_effect_classes"
+        return True, None
+
     def _finalize_remote_task_completion(self) -> bool:
         """Ensure MCP-backed tasks are marked done after a successful task run."""
         from millstone.artifact_providers.mcp import MCPTasklistProvider
@@ -2432,6 +2442,15 @@ class Orchestrator:
 
         provider = self._outer_loop_manager.tasklist_provider
         if not isinstance(provider, MCPTasklistProvider):
+            return True
+
+        allowed, reason = self._can_finalize_remote_task_completion()
+        if not allowed:
+            self.log(
+                "remote_task_completion_skipped",
+                task_id=self._current_task_id,
+                reason=reason,
+            )
             return True
 
         try:

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -528,6 +528,7 @@ class Orchestrator:
         }  # Aggregated severity counts
         self._current_task_text: str = ""  # Current task text for review metrics
         self._selected_task_item: TasklistItem | None = None
+        self._resumed_task_state: dict[str, Any] | None = None
         self._tasklist_fix_scope_active: bool = False
         self._task_impossible_decision: ReviewDecision | None = None
         self._task_previous_diff: str | None = (
@@ -998,7 +999,7 @@ class Orchestrator:
 
     def _build_state_snapshot(self, halt_reason: str = "") -> dict[str, Any]:
         """Build the standard state payload for resumable halts."""
-        return {
+        state = {
             "current_task_num": self.current_task_num,
             "builder_session_id": self.builder_session_id,
             "reviewer_session_id": self.reviewer_session_id,
@@ -1009,6 +1010,75 @@ class Orchestrator:
             "halt_reason": halt_reason,
             "timestamp": datetime.now().isoformat(),
         }
+        state.update(self._selected_task_state_snapshot())
+        return state
+
+    def _serialize_task_item(self, task: TasklistItem | None) -> dict[str, Any] | None:
+        if task is None:
+            return None
+        return {
+            "task_id": task.task_id,
+            "title": task.title,
+            "status": task.status.value,
+            "design_ref": task.design_ref,
+            "opportunity_ref": task.opportunity_ref,
+            "risk": task.risk,
+            "tests": task.tests,
+            "criteria": task.criteria,
+            "acceptance_criteria": list(task.acceptance_criteria or []),
+            "context": task.context,
+            "raw": task.raw,
+        }
+
+    def _deserialize_task_item(self, payload: dict[str, Any] | None) -> TasklistItem | None:
+        if not payload:
+            return None
+        status_value = payload.get("status", TaskStatus.todo.value)
+        with contextlib.suppress(ValueError):
+            status = TaskStatus(status_value)
+            return TasklistItem(
+                task_id=payload.get("task_id", ""),
+                title=payload.get("title", "") or "task",
+                status=status,
+                design_ref=payload.get("design_ref"),
+                opportunity_ref=payload.get("opportunity_ref"),
+                risk=payload.get("risk"),
+                tests=payload.get("tests"),
+                criteria=payload.get("criteria"),
+                acceptance_criteria=list(payload.get("acceptance_criteria") or []),
+                context=payload.get("context"),
+                raw=payload.get("raw"),
+            )
+        return None
+
+    def _selected_task_state_snapshot(self) -> dict[str, Any]:
+        """Capture selected-task identity so inner-loop resumes keep the same scope."""
+        snapshot = {
+            "selected_task_line": self._selected_task_line,
+            "selected_task_title": self._selected_task_title or self.current_task_title or None,
+            "selected_task_context_file": self._selected_task_context_file,
+            "current_task_id": self._current_task_id,
+            "current_task_text": self._current_task_text,
+            "current_task_group": self.current_task_group,
+            "current_task_risk": self.current_task_risk,
+            "selected_task_item": self._serialize_task_item(self._get_selected_task_item()),
+        }
+        return {k: v for k, v in snapshot.items() if v is not None}
+
+    def _restore_selected_task_state(self, state: dict[str, Any]) -> None:
+        """Restore saved selected-task identity for a resumed inner-loop run."""
+        keys = {
+            "selected_task_line",
+            "selected_task_title",
+            "selected_task_context_file",
+            "current_task_id",
+            "current_task_text",
+            "current_task_group",
+            "current_task_risk",
+            "selected_task_item",
+        }
+        snapshot = {k: state.get(k) for k in keys if state.get(k) is not None}
+        self._resumed_task_state = snapshot or None
 
     def save_state(self, halt_reason: str = "", **extra: object) -> None:
         """Save current orchestration state to state.json.
@@ -2237,16 +2307,12 @@ class Orchestrator:
         )
 
     def _current_task_acceptance_criteria(self) -> list[str]:
-        from millstone.artifact_providers.file import FileTasklistProvider
-
-        provider = self._outer_loop_manager.tasklist_provider
-        if not isinstance(provider, FileTasklistProvider):
-            task = self._get_selected_task_item()
-            if task is not None:
-                if task.acceptance_criteria:
-                    return task.acceptance_criteria
-                if task.criteria:
-                    return [task.criteria]
+        task = self._get_selected_task_item()
+        if task is not None:
+            if task.acceptance_criteria:
+                return task.acceptance_criteria
+            if task.criteria:
+                return [task.criteria]
         return self.extract_current_task_acceptance_criteria()
 
     def _tasklist_fix_targeted_update_instruction(self) -> str:
@@ -2356,6 +2422,31 @@ class Orchestrator:
             and getattr(provider, "_agent_callback", None) is None
         ):
             provider.set_agent_callback(lambda p, **k: self.run_agent(p, role="author", **k))
+
+    def _finalize_remote_task_completion(self) -> bool:
+        """Ensure MCP-backed tasks are marked done after a successful task run."""
+        from millstone.artifact_providers.mcp import MCPTasklistProvider
+
+        if self.task or not self._current_task_id:
+            return True
+
+        provider = self._outer_loop_manager.tasklist_provider
+        if not isinstance(provider, MCPTasklistProvider):
+            return True
+
+        try:
+            self._ensure_tasklist_provider_author_callback()
+            provider.update_task_status(self._current_task_id, TaskStatus.done)
+            self.log("remote_task_marked_complete", task_id=self._current_task_id)
+            return True
+        except Exception as exc:
+            self.log(
+                "remote_task_completion_failed",
+                task_id=self._current_task_id,
+                error=str(exc),
+            )
+            progress(f"{self._task_prefix()} ERROR: failed to mark remote task complete: {exc}")
+            return False
 
     def extract_current_task_line(self) -> str:
         if self._selected_task_line:
@@ -2499,6 +2590,81 @@ class Orchestrator:
         )
         self.completed_task_count = self._tasklist_manager.completed_task_count
         return result
+
+    def _finalize_automatic_compaction(self) -> bool:
+        """Commit tracked tasklist compaction so it cannot spill into the next task."""
+        from millstone.artifact_providers.mcp import MCPTasklistProvider
+
+        provider = self._outer_loop_manager.tasklist_provider
+        if isinstance(provider, MCPTasklistProvider):
+            return True
+
+        status_lines = self._get_working_tree_status_lines()
+        if status_lines is None:
+            self.log("automatic_compaction_status_failed")
+            progress("Automatic compaction completed, but git status failed.")
+            return False
+        if not status_lines:
+            return True
+
+        tasklist_path = str(self.tasklist)
+        remaining_files = [line.split()[-1] for line in status_lines if line.strip()]
+        unexpected_files = [path for path in remaining_files if path != tasklist_path]
+        if unexpected_files:
+            self.log(
+                "automatic_compaction_unexpected_changes",
+                tasklist=tasklist_path,
+                files=",".join(unexpected_files),
+            )
+            progress(
+                "Automatic compaction left unexpected working-tree changes; halting before the next task."
+            )
+            return False
+
+        add_result = subprocess.run(
+            ["git", "add", "--", tasklist_path],
+            cwd=self.repo_dir,
+            capture_output=True,
+            text=True,
+        )
+        if add_result.returncode != 0:
+            self.log(
+                "automatic_compaction_git_add_failed",
+                tasklist=tasklist_path,
+                error=add_result.stderr.strip(),
+            )
+            progress("Automatic compaction could not stage the tasklist change.")
+            return False
+
+        commit_result = subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                "Compact completed tasks in tasklist\n\nGenerated with millstone orchestrator",
+            ],
+            cwd=self.repo_dir,
+            capture_output=True,
+            text=True,
+        )
+        if commit_result.returncode != 0:
+            self.log(
+                "automatic_compaction_commit_failed",
+                tasklist=tasklist_path,
+                error=commit_result.stderr.strip(),
+            )
+            progress("Automatic compaction could not commit the tasklist change.")
+            return False
+
+        self._update_loc_baseline()
+        progress("Auto-committed tasklist compaction.")
+        return True
+
+    def _run_automatic_compaction(self) -> bool:
+        """Run compaction and finalize any tracked tasklist changes immediately."""
+        if not self.run_compaction():
+            return False
+        return self._finalize_automatic_compaction()
 
     def run_eval(self, coverage: bool = False, mode: str | None = None) -> dict:
         def _emit_eval_evidence(eval_result: dict) -> None:
@@ -3695,6 +3861,9 @@ class Orchestrator:
 
         # Determine task text and metadata
         _mcp_task_item: Any = None  # Set when MCP provider supplies the current task
+        restored_task_state = self._resumed_task_state if not self.task else None
+        self._resumed_task_state = None
+
         if self.task:
             task_display = self.task[:50] + "..." if len(self.task) > 50 else self.task
             self.current_task_title = task_display
@@ -3706,6 +3875,17 @@ class Orchestrator:
             self._selected_task_title = self.current_task_title
             self._selected_task_line = task_text
             self._selected_task_context_file = task_metadata.get("context")
+        elif restored_task_state:
+            self.current_task_title = restored_task_state.get("selected_task_title") or "task"
+            task_text = restored_task_state.get("current_task_text") or self.current_task_title
+            self.apply_risk_settings(restored_task_state.get("current_task_risk"))
+            self.current_task_group = restored_task_state.get("current_task_group")
+            self._selected_task_title = self.current_task_title
+            self._selected_task_line = restored_task_state.get("selected_task_line") or task_text
+            self._selected_task_context_file = restored_task_state.get("selected_task_context_file")
+            self._selected_task_item = self._deserialize_task_item(
+                restored_task_state.get("selected_task_item")
+            )
         else:
             # When the tasklist is MCP-backed, derive task title and ID from the
             # remote provider's cached task list instead of reading a local file
@@ -3749,7 +3929,9 @@ class Orchestrator:
         self._current_task_text = task_text
         # Prefer canonical task_id from metadata (stable, ontology-compliant identity).
         # When an MCP provider supplied the task, use its remote ID directly.
-        if _mcp_task_item is not None:
+        if restored_task_state and restored_task_state.get("current_task_id"):
+            self._current_task_id = restored_task_state["current_task_id"]
+        elif _mcp_task_item is not None:
             self._current_task_id = _mcp_task_item.task_id
         elif self.task:
             _task_meta = self._tasklist_manager._parse_task_metadata(task_text)
@@ -3764,7 +3946,8 @@ class Orchestrator:
                 re.sub(r"[^a-z0-9]+", "-", task_text.lower()).strip("-")[:30] or None
             )
 
-        self._selected_task_item = _mcp_task_item
+        if _mcp_task_item is not None:
+            self._selected_task_item = _mcp_task_item
         if not self.task and self._selected_task_item is None:
             with contextlib.suppress(Exception):
                 pending_provider_tasks = [
@@ -3900,14 +4083,13 @@ class Orchestrator:
             self.log("research_completed", task=task_text[:200], output_file=str(output_file))
             if not self.task:
                 self.mark_task_complete()
-                # Close remote task for MCP providers — mark_task_complete()
-                # only updates the local tasklist file, which is a no-op when
-                # the task lives on a remote backend (GitHub Issues, Linear, …).
-                from millstone.artifact_providers.mcp import MCPTasklistProvider
-
-                provider = self._outer_loop_manager.tasklist_provider
-                if isinstance(provider, MCPTasklistProvider) and self._current_task_id:
-                    provider.update_task_status(self._current_task_id, TaskStatus.done)
+                if not self._finalize_remote_task_completion():
+                    _worker_finish(
+                        "failed",
+                        review_summary=builder_output[:4000],
+                        error="remote_task_completion",
+                    )
+                    return False
             progress(f"{self._task_prefix()} Research completed -> {output_file}")
             _worker_finish("success", review_summary=builder_output[:4000])
             return True
@@ -4165,6 +4347,10 @@ class Orchestrator:
                 # Update baseline so next task measures LoC from this commit
                 self._update_loc_baseline()
 
+                if not self._finalize_remote_task_completion():
+                    loop_state["failure_reason"] = "remote_task_completion"
+                    return False
+
                 if self.eval_on_commit and not self._run_eval_on_commit(task_text=task_text):
                     loop_state["failure_reason"] = "eval_regression"
                     return False
@@ -4173,6 +4359,9 @@ class Orchestrator:
                 return True
 
             if self.delegate_commit():
+                if not self._finalize_remote_task_completion():
+                    loop_state["failure_reason"] = "remote_task_completion"
+                    return False
                 if self.eval_on_commit and not self._run_eval_on_commit(task_text=task_text):
                     loop_state["failure_reason"] = "eval_regression"
                     return False
@@ -4560,6 +4749,7 @@ class Orchestrator:
                     # Inner-loop resume (LoC/sensitive-file halt): user has
                     # already reviewed the diff, so skip mechanical checks.
                     self._skip_mechanical_checks = True
+                    self._restore_selected_task_state(state)
             else:
                 print("Warning: --continue specified but no saved state found.")
                 print("Running normally...")
@@ -4620,7 +4810,21 @@ class Orchestrator:
                         "Skipping startup tasklist compaction because the working tree has uncommitted changes."
                     )
                 else:
-                    self.run_compaction()
+                    if not self._run_automatic_compaction():
+                        self.log(
+                            "run_completed",
+                            result="HALTED",
+                            reason="startup_compaction_failed",
+                            tasks_completed="0",
+                        )
+                        self._print_run_summary(
+                            0,
+                            1,
+                            "startup_compaction_failed",
+                            run_start_time,
+                            remaining="unknown",
+                        )
+                        return 1
 
         # Capture baseline eval if eval_on_commit or eval_on_task is enabled
         # Note: skip_eval only affects eval_on_task gate, not eval_on_commit
@@ -4717,8 +4921,24 @@ class Orchestrator:
                     # motivation to reorganize and drop unchecked tasks.
                     if not self.task:
                         self.completed_task_count = self.count_completed_tasks()
-                        if self.should_compact():
-                            self.run_compaction()
+                        if self.should_compact() and not self._run_automatic_compaction():
+                            progress(
+                                f"=== HALTED after {tasks_completed} task(s) === automatic compaction failed"
+                            )
+                            self.log(
+                                "run_completed",
+                                result="HALTED",
+                                reason="inter_task_compaction_failed",
+                                tasks_completed=str(tasks_completed),
+                            )
+                            self._print_run_summary(
+                                tasks_completed,
+                                tasks_failed + 1,
+                                "inter_task_compaction_failed",
+                                run_start_time,
+                                remaining=self._remaining_count(task_num),
+                            )
+                            return 1
                 else:
                     tasks_failed += 1
                     # Stop on first failure

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -91,6 +91,7 @@ class BuilderArtifact:
     git_diff: str
     builder_committed: bool = False
     task_repair: TasklistItem | None = None
+    sanity_flags: str | None = None
 
 
 @dataclass
@@ -3630,6 +3631,7 @@ class Orchestrator:
         builder_output: str = "",
         git_diff: str | None = None,
         task_repair: TasklistItem | None = None,
+        sanity_flags: str | None = None,
     ) -> str:
         """Generate prompt for review."""
         prompt = self.load_prompt("review_prompt.md")
@@ -3654,6 +3656,19 @@ class Orchestrator:
         else:
             criteria_blurb = ""
         prompt = prompt.replace("{{ACCEPTANCE_CRITERIA}}", criteria_blurb)
+        # Inject sanity check flags if present
+        sanity_blurb = ""
+        if sanity_flags:
+            sanity_blurb = (
+                "\n\n---\n\n## Automated Sanity Check Flags\n\n"
+                "The automated pre-review sanity check flagged the following concerns. "
+                "Evaluate these flags as part of your review — they may be false positives:\n\n"
+                f"{sanity_flags}\n"
+            )
+        if "{{SANITY_FLAGS}}" in prompt:
+            prompt = prompt.replace("{{SANITY_FLAGS}}", sanity_blurb)
+        elif sanity_blurb:
+            prompt += sanity_blurb
         selected_scope = self._selected_task_scope_block()
         if selected_scope:
             prompt += "\n\n---\n\n## Review Scope\n\n"
@@ -3705,8 +3720,8 @@ class Orchestrator:
         task_description = self.task if self.task else self.extract_current_task_title()
         return self.load_prompt("research_prompt.md").replace("{{TASK}}", task_description)
 
-    def sanity_check_impl(self, agent_output: str, git_status: str, git_diff: str) -> bool:
-        # Delegates to InnerLoopManager
+    def sanity_check_impl(self, agent_output: str, git_status: str, git_diff: str) -> str | None:
+        # Delegates to InnerLoopManager.  Returns flag reason or None.
         return self._inner_loop_manager.sanity_check_impl(
             agent_output=agent_output,
             git_status=git_status,
@@ -3715,8 +3730,8 @@ class Orchestrator:
             run_agent_callback=self.run_agent,
         )
 
-    def sanity_check_review(self, review_output: str) -> bool:
-        # Delegates to InnerLoopManager
+    def sanity_check_review(self, review_output: str) -> str | None:
+        # Delegates to InnerLoopManager.  Returns flag reason or None.
         return self._inner_loop_manager.sanity_check_review(
             review_output=review_output,
             load_prompt_callback=self.load_prompt,
@@ -4232,8 +4247,10 @@ class Orchestrator:
                     note="after_empty_diff_retry",
                 )
 
-            if not self.sanity_check_impl(artifact.output, artifact.git_status, artifact.git_diff):
-                return False, "Sanity check failed"
+            sanity_flags = self.sanity_check_impl(
+                artifact.output, artifact.git_status, artifact.git_diff
+            )
+            artifact.sanity_flags = sanity_flags
 
             return True, None
 
@@ -4246,7 +4263,12 @@ class Orchestrator:
             reviewer_resume = self.reviewer_session_id
 
             review_output = self.run_agent(
-                self.get_review_prompt(artifact.output, artifact.git_diff, artifact.task_repair),
+                self.get_review_prompt(
+                    artifact.output,
+                    artifact.git_diff,
+                    artifact.task_repair,
+                    sanity_flags=artifact.sanity_flags,
+                ),
                 role="reviewer",
                 output_schema="review_decision",
                 resume=reviewer_resume,
@@ -4263,13 +4285,18 @@ class Orchestrator:
 
             # Only sanity check if we couldn't parse a valid verdict
             # This allows reviewers like Codex that output just JSON without markdown
+            review_sanity_flag: str | None = None
             if decision is None:
                 is_empty_fallback = (
                     "Reviewer returned empty response" in review_output
                     and "REQUEST_CHANGES" in review_output
                 )
-                if not is_empty_fallback and not self.sanity_check_review(review_output):
-                    raise Exception("Review sanity check failed")
+                if not is_empty_fallback:
+                    review_sanity_flag = self.sanity_check_review(review_output)
+                    if review_sanity_flag:
+                        print(f"WARN: Review sanity check flagged: {review_sanity_flag}")
+                        # Treat unparseable + flagged review as REQUEST_CHANGES
+                        approved = False
 
             # Update metrics and diff for false positive detection
             if decision:
@@ -4291,6 +4318,10 @@ class Orchestrator:
                 feedback_text = decision.review or decision.summary or feedback_text
                 if decision.status == ReviewStatus.TASK_IMPOSSIBLE:
                     feedback_text = self._task_impossible_feedback(decision)
+            if review_sanity_flag:
+                feedback_text = (
+                    f"[Review sanity check flagged: {review_sanity_flag}]\n\n" + feedback_text
+                )
 
             return BuilderVerdict(approved, decision, review_output, feedback_text)
 

--- a/tests/e2e/test_e2e_sanity_advisory.py
+++ b/tests/e2e/test_e2e_sanity_advisory.py
@@ -1,0 +1,232 @@
+"""E2E tests for advisory sanity check → reviewer/builder information flow.
+
+These tests verify that sanity check flags propagate correctly through the
+orchestrator pipeline rather than halting the session:
+
+1. Impl sanity flags arrive in the reviewer prompt as advisory context.
+2. Review sanity flags arrive in the builder feedback text.
+3. The full flow continues (no halt) when sanity checks flag concerns.
+4. Clean sanity checks produce no flag artifacts in prompts.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from millstone.runtime.orchestrator import Orchestrator
+from tests.e2e.conftest import StubCli
+
+_original_subprocess_run = subprocess.run
+
+_APPROVED_JSON = (
+    '{"status": "APPROVED", "review": "Looks good", "summary": "Looks good!",'
+    ' "findings": [], "findings_by_severity":'
+    ' {"critical": [], "high": [], "medium": [], "low": [], "nit": []},'
+    ' "impossible_condition": null, "tasklist_fix_recommendation": null}'
+)
+_REQUEST_CHANGES_JSON = (
+    '{"status": "REQUEST_CHANGES", "review": "Needs work", "summary": "Issues found",'
+    ' "findings": ["Missing tests"], "findings_by_severity":'
+    ' {"critical": [], "high": ["Missing tests"], "medium": [], "low": [], "nit": []},'
+    ' "impossible_condition": null, "tasklist_fix_recommendation": null}'
+)
+_SANITY_OK_JSON = '{"status": "OK", "reason": ""}'
+_SANITY_FLAG_JSON = '{"status": "HALT", "reason": "Builder output looks incoherent — no meaningful code changes detected"}'
+
+
+def _make_file_change(filename: str = "feature.py", content: str = "def f(): pass\n"):
+    def _effect(repo: Path) -> None:
+        (repo / filename).write_text(content)
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=False)
+
+    return _effect
+
+
+def _do_commit(repo: Path) -> None:
+    subprocess.run(
+        ["git", "commit", "-m", "stub-cli e2e test commit"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+
+
+class TestImplSanityFlagsReachReviewer:
+    """Impl sanity flags are injected into the reviewer prompt."""
+
+    def test_flagged_impl_injects_sanity_section_into_reviewer_prompt(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """When impl sanity check returns HALT, the reviewer prompt contains
+        the flag reason under 'Automated Sanity Check Flags'."""
+        stub_cli.add(role="author", output="gibberish output", side_effect=_make_file_change())
+        stub_cli.add(role="sanity", output=_SANITY_FLAG_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+
+        reviewer_calls = [c for c in stub_cli.calls if c.role == "reviewer"]
+        assert reviewer_calls, "No reviewer call recorded"
+        reviewer_prompt = reviewer_calls[0].prompt
+
+        assert "Automated Sanity Check Flags" in reviewer_prompt
+        assert "incoherent" in reviewer_prompt
+        assert "false positives" in reviewer_prompt.lower()
+
+    def test_clean_impl_has_no_sanity_section_in_reviewer_prompt(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """When impl sanity check is OK, the reviewer prompt has no sanity flags section."""
+        stub_cli.add(role="author", output="Implemented feature.", side_effect=_make_file_change())
+        stub_cli.add(role="sanity", output=_SANITY_OK_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+
+        reviewer_calls = [c for c in stub_cli.calls if c.role == "reviewer"]
+        assert reviewer_calls
+        reviewer_prompt = reviewer_calls[0].prompt
+
+        assert "Automated Sanity Check Flags" not in reviewer_prompt
+        assert "SANITY" not in reviewer_prompt.upper() or "{{SANITY_FLAGS}}" not in reviewer_prompt
+
+
+class TestReviewSanityFlagsReachBuilder:
+    """Review sanity flags flow into builder feedback when review is unparseable."""
+
+    def test_flagged_review_includes_reason_in_builder_feedback(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """When the review is unparseable and review sanity check flags it,
+        the builder gets the flag reason prepended to its feedback and the
+        review is treated as REQUEST_CHANGES (builder gets a second chance)."""
+        stub_cli.add(role="author", output="Implemented.", side_effect=_make_file_change())
+        stub_cli.add(role="sanity", output=_SANITY_OK_JSON)  # impl sanity: OK
+        # Unparseable review output — triggers review sanity check
+        stub_cli.add(role="reviewer", output="I dunno, looks weird to me maybe?")
+        stub_cli.add(
+            role="sanity",
+            output='{"status": "HALT", "reason": "Review is incoherent and provides no actionable feedback"}',
+        )
+        # Builder retry after REQUEST_CHANGES from flagged review
+        stub_cli.add(
+            role="author",
+            output="Fixed.",
+            side_effect=_make_file_change("feature.py", "def f(): return 1\n"),
+        )
+        stub_cli.add(role="sanity", output=_SANITY_OK_JSON)  # impl sanity on retry: OK
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+
+        # The retry builder call should contain the review sanity flag in its prompt
+        author_calls = [c for c in stub_cli.calls if c.role == "author"]
+        assert len(author_calls) >= 2, f"Expected retry, got {len(author_calls)} author calls"
+        retry_prompt = author_calls[1].prompt
+        assert "Review sanity check flagged" in retry_prompt or "incoherent" in retry_prompt
+
+
+class TestFullFlowContinuesWithFlags:
+    """Sanity flags never halt the session — the flow always continues."""
+
+    def test_flagged_impl_approved_by_reviewer_commits(
+        self, stub_cli: StubCli, temp_repo: Path, capsys
+    ) -> None:
+        """Even with an impl sanity flag, if the reviewer approves, the task
+        commits successfully. The sanity flag is advisory, not a veto."""
+        stub_cli.add(role="author", output="looks like gibberish", side_effect=_make_file_change())
+        stub_cli.add(role="sanity", output=_SANITY_FLAG_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "SANITY FLAG" in captured.out
+        assert "Completed and committed" in captured.out
+
+    def test_flagged_impl_rejected_by_reviewer_loops(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """When impl is flagged and reviewer rejects, the fix loop continues
+        normally (no halt). Second cycle succeeds."""
+        # Cycle 1: flagged impl → reviewer rejects
+        stub_cli.add(role="author", output="bad attempt", side_effect=_make_file_change())
+        stub_cli.add(role="sanity", output=_SANITY_FLAG_JSON)
+        stub_cli.add(role="reviewer", output=_REQUEST_CHANGES_JSON)
+        # Cycle 2: clean impl → reviewer approves
+        stub_cli.add(
+            role="author",
+            output="fixed it",
+            side_effect=_make_file_change("feature.py", "def fixed(): return True\n"),
+        )
+        stub_cli.add(role="sanity", output=_SANITY_OK_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+
+        # Verify two author calls (original + fix cycle)
+        author_calls = [c for c in stub_cli.calls if c.role == "author"]
+        assert len(author_calls) == 2
+
+        # Verify two sanity calls (one per cycle)
+        sanity_calls = [c for c in stub_cli.calls if c.role == "sanity"]
+        assert len(sanity_calls) == 2
+
+    def test_no_stop_file_remains_after_flagged_run(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """STOP.md must never persist after a run with sanity flags."""
+        stub_cli.add(role="author", output="gibberish", side_effect=_make_file_change())
+        stub_cli.add(role="sanity", output=_SANITY_FLAG_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+
+            assert exit_code == 0
+            assert not (orch.work_dir / "STOP.md").exists()
+        finally:
+            orch.cleanup()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -382,22 +382,22 @@ class TestFullFlow:
         finally:
             orch.cleanup()
 
-    def test_sanity_check_creates_stop_file(self, temp_repo):
+    def test_sanity_check_flags_passed_to_reviewer(self, temp_repo, capsys):
         """
-        Scenario: Sanity check agent detects gibberish and creates STOP.md.
-        Expected: Exit 1 immediately.
+        Scenario: Sanity check agent flags concerns about builder output.
+        Expected: Flags are injected into reviewer prompt as advisory context,
+                  session continues normally instead of halting.
         """
         orch = Orchestrator()
-
-        def create_stop(repo):
-            # Create STOP.md in orchestrator's work dir
-            stop_file = orch.work_dir / "STOP.md"
-            stop_file.write_text("Builder output appears to be gibberish")
 
         responses = (
             ResponseBuilder()
             .on_builder(make_file_change(), output="asdfghjkl gibberish ???")
-            .on_sanity_check(response="Creating STOP.md", side_effect=create_stop)
+            .on_sanity_check(
+                response='{"status": "HALT", "reason": "Builder output appears to be gibberish"}'
+            )
+            .on_reviewer(approve=True)
+            .on_commit(success=True)
             .build()
         )
 
@@ -405,8 +405,11 @@ class TestFullFlow:
             with patch("subprocess.run", side_effect=make_mock_runner(temp_repo, responses)):
                 exit_code = orch.run()
 
-            assert exit_code == 1
+            # Session continues to review instead of halting
+            assert exit_code == 0
             assert orch.cycle == 1
+            captured = capsys.readouterr()
+            assert "SANITY FLAG" in captured.out
         finally:
             orch.cleanup()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1989,6 +1989,85 @@ All done."""
             finally:
                 orch.cleanup()
 
+    def test_run_single_task_closes_mcp_task_on_success(self, temp_repo):
+        """Approved MCP-backed tasks are explicitly marked done after commit."""
+        from millstone.artifact_providers.mcp import MCPTasklistProvider
+        from millstone.artifacts.models import TasklistItem, TaskStatus
+
+        orch = Orchestrator(tasklist="docs/tasklist.md", quiet=True)
+        try:
+            mock_mcp = MagicMock(spec=MCPTasklistProvider)
+            mock_mcp._agent_callback = None
+            task = TasklistItem(task_id="GH-42", title="Remote task", status=TaskStatus.todo)
+            mock_mcp.get_prompt_placeholders.return_value = {}
+            mock_mcp.list_tasks.return_value = [task]
+            mock_mcp.get_task.return_value = task
+            orch._outer_loop_manager.tasklist_provider = mock_mcp
+
+            def fake_run_agent(prompt, role="default", **kwargs):
+                if role == "author":
+                    (temp_repo / "impl.py").write_text("value = 1\n")
+                    return "Implemented remote task."
+                if role == "reviewer":
+                    return (
+                        '{"status":"APPROVED","review":"ok","summary":"ok",'
+                        '"findings":[],"findings_by_severity":{"critical":[],"high":[],'
+                        '"medium":[],"low":[],"nit":[]},"impossible_condition":null,'
+                        '"tasklist_fix_recommendation":null}'
+                    )
+                raise AssertionError(f"Unexpected role: {role}")
+
+            with (
+                patch.object(orch, "run_agent", side_effect=fake_run_agent),
+                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "delegate_commit", return_value=True),
+            ):
+                assert orch.run_single_task() is True
+
+            mock_mcp.update_task_status.assert_called_once_with("GH-42", TaskStatus.done)
+        finally:
+            orch.cleanup()
+
+    def test_run_single_task_fails_when_mcp_completion_update_fails(self, temp_repo):
+        """Remote completion failures are surfaced instead of silently ignored."""
+        from millstone.artifact_providers.mcp import MCPTasklistProvider
+        from millstone.artifacts.models import TasklistItem, TaskStatus
+
+        orch = Orchestrator(tasklist="docs/tasklist.md", quiet=True)
+        try:
+            mock_mcp = MagicMock(spec=MCPTasklistProvider)
+            mock_mcp._agent_callback = None
+            task = TasklistItem(task_id="GH-42", title="Remote task", status=TaskStatus.todo)
+            mock_mcp.get_prompt_placeholders.return_value = {}
+            mock_mcp.list_tasks.return_value = [task]
+            mock_mcp.get_task.return_value = task
+            mock_mcp.update_task_status.side_effect = RuntimeError("remote outage")
+            orch._outer_loop_manager.tasklist_provider = mock_mcp
+
+            def fake_run_agent(prompt, role="default", **kwargs):
+                if role == "author":
+                    (temp_repo / "impl.py").write_text("value = 1\n")
+                    return "Implemented remote task."
+                if role == "reviewer":
+                    return (
+                        '{"status":"APPROVED","review":"ok","summary":"ok",'
+                        '"findings":[],"findings_by_severity":{"critical":[],"high":[],'
+                        '"medium":[],"low":[],"nit":[]},"impossible_condition":null,'
+                        '"tasklist_fix_recommendation":null}'
+                    )
+                raise AssertionError(f"Unexpected role: {role}")
+
+            with (
+                patch.object(orch, "run_agent", side_effect=fake_run_agent),
+                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "delegate_commit", return_value=True),
+            ):
+                assert orch.run_single_task() is False
+
+            mock_mcp.update_task_status.assert_called_once_with("GH-42", TaskStatus.done)
+        finally:
+            orch.cleanup()
+
 
 class TestIsApproved:
     """Tests for approval detection."""
@@ -3657,6 +3736,57 @@ compact_threshold = 50
         finally:
             orch.cleanup()
 
+    def test_finalize_automatic_compaction_commits_tracked_tasklist(self, temp_repo):
+        """Tracked tasklist compaction is committed immediately and updates baseline."""
+        tasklist_path = temp_repo / "docs" / "tasklist.md"
+        tasklist_path.parent.mkdir(parents=True, exist_ok=True)
+        tasklist_path.write_text("# Tasklist\n\n- [x] Done 1\n- [ ] Pending\n")
+        subprocess.run(
+            ["git", "add", "docs/tasklist.md"], cwd=temp_repo, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add tracked tasklist"],
+            cwd=temp_repo,
+            check=True,
+            capture_output=True,
+        )
+
+        orch = Orchestrator(tasklist="docs/tasklist.md", quiet=True)
+        try:
+            orch._init_loc_baseline()
+            tasklist_path.write_text("# Tasklist\n\n## Completed\n\nDone 1.\n\n- [ ] Pending\n")
+
+            assert orch._finalize_automatic_compaction() is True
+
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=temp_repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            assert status == ""
+
+            head = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=temp_repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            assert orch.loc_baseline_ref == head
+
+            message = subprocess.run(
+                ["git", "log", "-1", "--pretty=%B"],
+                cwd=temp_repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            assert "Compact completed tasks in tasklist" in message
+        finally:
+            orch.cleanup()
+
 
 class TestCompactionSanityCheck:
     """Tests for compaction sanity check functionality."""
@@ -4764,6 +4894,99 @@ class TestStatePersistence:
             assert state["cycle"] == 1
             assert state["halt_reason"] == "loc_threshold_exceeded:600"
             assert "timestamp" in state
+        finally:
+            orch.cleanup()
+
+    def test_save_state_persists_selected_task_identity(self, temp_repo):
+        """save_state captures selected-task identity for inner-loop resume."""
+        from millstone.artifacts.models import TasklistItem, TaskStatus
+
+        tasklist = temp_repo / "docs" / "tasklist.md"
+        tasklist.parent.mkdir(parents=True, exist_ok=True)
+        tasklist.write_text("# Tasklist\n\n- [ ] Task 1\n- [ ] Task 2\n")
+
+        orch = Orchestrator(tasklist="docs/tasklist.md")
+        try:
+            orch._selected_task_line = "- [ ] Task 1"
+            orch._selected_task_title = "Task 1"
+            orch._selected_task_context_file = ".millstone/context/task-1.md"
+            orch._current_task_id = "task-1"
+            orch._current_task_text = "Task 1\n  - Risk: low"
+            orch.current_task_group = "Core"
+            orch.current_task_risk = "low"
+            orch._selected_task_item = TasklistItem(
+                task_id="task-1",
+                title="Task 1",
+                status=TaskStatus.todo,
+                acceptance_criteria=["Criterion A"],
+                context=".millstone/context/task-1.md",
+            )
+
+            orch.save_state(halt_reason="policy:loc_threshold")
+
+            state = json.loads(orch._get_state_file_path().read_text())
+            assert state["selected_task_line"] == "- [ ] Task 1"
+            assert state["selected_task_title"] == "Task 1"
+            assert state["current_task_id"] == "task-1"
+            assert state["current_task_group"] == "Core"
+            assert state["current_task_risk"] == "low"
+            assert state["selected_task_item"]["acceptance_criteria"] == ["Criterion A"]
+        finally:
+            orch.cleanup()
+
+    def test_run_single_task_uses_resumed_selected_task_scope(self, temp_repo):
+        """run_single_task preserves the saved selected task on inner-loop resume."""
+        from millstone.artifacts.models import TaskStatus
+
+        tasklist = temp_repo / "docs" / "tasklist.md"
+        tasklist.parent.mkdir(parents=True, exist_ok=True)
+        tasklist.write_text("# Tasklist\n\n- [x] Task 1\n- [ ] Task 2\n")
+
+        orch = Orchestrator(tasklist="docs/tasklist.md", continue_run=True, quiet=True)
+        try:
+            orch._resumed_task_state = {
+                "selected_task_line": "- [ ] Task 1",
+                "selected_task_title": "Task 1",
+                "current_task_id": "task-1",
+                "current_task_text": "Task 1",
+                "selected_task_item": {
+                    "task_id": "task-1",
+                    "title": "Task 1",
+                    "status": TaskStatus.todo.value,
+                    "acceptance_criteria": ["Keep using Task 1"],
+                    "criteria": None,
+                    "design_ref": None,
+                    "opportunity_ref": None,
+                    "risk": None,
+                    "tests": None,
+                    "context": None,
+                    "raw": None,
+                },
+            }
+
+            def fake_run_agent(prompt, role="default", **kwargs):
+                if role == "author":
+                    assert "Task 1" in prompt
+                    assert "Task 2" not in prompt.split("## Selected Task")[-1]
+                    (temp_repo / "impl.py").write_text("value = 1\n")
+                    return "Implemented Task 1."
+                if role == "reviewer":
+                    return (
+                        '{"status":"APPROVED","review":"ok","summary":"ok",'
+                        '"findings":[],"findings_by_severity":{"critical":[],"high":[],'
+                        '"medium":[],"low":[],"nit":[]},"impossible_condition":null,'
+                        '"tasklist_fix_recommendation":null}'
+                    )
+                raise AssertionError(f"Unexpected role: {role}")
+
+            with (
+                patch.object(orch, "run_agent", side_effect=fake_run_agent),
+                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "delegate_commit", return_value=True),
+            ):
+                assert orch.run_single_task() is True
+                assert orch._current_task_id == "task-1"
+                assert orch.current_task_title == "Task 1"
         finally:
             orch.cleanup()
 
@@ -15098,6 +15321,48 @@ enforce_single_task = true
 
             log_content = orch.log_file.read_text()
             assert "tasklist_scope_violation" in log_content
+        finally:
+            orch.cleanup()
+
+    def test_mechanical_checks_allows_compacted_completed_summary_update(self, temp_repo):
+        """mechanical_checks accepts compacted tasklists that consume only the selected task."""
+        from millstone.runtime.orchestrator import POLICY_FILE_NAME, WORK_DIR_NAME
+
+        config_dir = temp_repo / WORK_DIR_NAME
+        config_dir.mkdir(exist_ok=True)
+        policy_file = config_dir / POLICY_FILE_NAME
+        policy_file.write_text("""
+[limits]
+max_loc_per_task = 10000
+
+[tasklist]
+enforce_single_task = true
+""")
+
+        orch = Orchestrator()
+        try:
+            tasklist_path = temp_repo / ".millstone" / "tasklist.md"
+            baseline = (
+                "# Tasklist\n\n"
+                "## Completed\n\n"
+                "Earlier work is summarized here.\n\n"
+                "## Remaining\n\n"
+                "- [ ] Task 1: Do something\n"
+                "- [ ] Task 2: Do another thing\n"
+            )
+            tasklist_path.write_text(baseline)
+            orch._tasklist_baseline = baseline
+
+            tasklist_path.write_text(
+                "# Tasklist\n\n"
+                "## Completed\n\n"
+                "Earlier work is summarized here. Task 1 is now complete.\n\n"
+                "## Remaining\n\n"
+                "- [ ] Task 2: Do another thing\n"
+            )
+
+            result = orch.mechanical_checks()
+            assert result is True
         finally:
             orch.cleanup()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2046,7 +2046,7 @@ All done."""
 
             with (
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "delegate_commit", return_value=True),
             ):
                 assert orch.run_single_task() is True
@@ -2097,7 +2097,7 @@ All done."""
 
             with (
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "delegate_commit", return_value=True),
             ):
                 assert orch.run_single_task() is False
@@ -2138,7 +2138,7 @@ All done."""
 
             with (
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "delegate_commit", return_value=True),
             ):
                 assert orch.run_single_task() is True
@@ -5060,7 +5060,7 @@ class TestStatePersistence:
 
             with (
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "delegate_commit", return_value=True),
             ):
                 assert orch.run_single_task() is True
@@ -17739,7 +17739,7 @@ class TestPrintFailureSummary:
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
                 patch.object(orch, "_analyze_task_complexity", return_value={}),
                 patch.object(orch, "mechanical_checks", return_value=True),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "save_task_metrics") as save_metrics,
                 patch.object(orch, "delegate_commit") as delegate_commit,
             ):
@@ -17821,7 +17821,7 @@ class TestPrintFailureSummary:
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
                 patch.object(orch, "_analyze_task_complexity", return_value={}),
                 patch.object(orch, "mechanical_checks", return_value=True),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "delegate_commit", return_value=True) as delegate_commit,
             ):
                 result = orch.run_single_task()
@@ -17892,7 +17892,7 @@ class TestPrintFailureSummary:
                 patch.object(orch, "run_agent", side_effect=fake_run_agent),
                 patch.object(orch, "_analyze_task_complexity", return_value={}),
                 patch.object(orch, "mechanical_checks", return_value=True),
-                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "sanity_check_impl", return_value=None),
                 patch.object(orch, "delegate_commit", return_value=True) as delegate_commit,
                 patch.object(provider, "update_task", wraps=provider.update_task) as update_task,
             ):
@@ -18132,8 +18132,8 @@ class TestUncheckedTaskPreservation:
                 with (
                     patch.object(orch, "git") as mock_git,
                     patch.object(orch, "mechanical_checks", return_value=True),
-                    patch.object(orch, "sanity_check_impl", return_value=True),
-                    patch.object(orch, "sanity_check_review", return_value=True),
+                    patch.object(orch, "sanity_check_impl", return_value=None),
+                    patch.object(orch, "sanity_check_review", return_value=None),
                     patch.object(orch, "delegate_commit", return_value=True),
                 ):
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1944,7 +1944,23 @@ All done."""
                 stderr="",
             )
 
-            orch = Orchestrator(tasklist="docs/tasklist.md", research=True, cli="claude")
+            profile = Profile(
+                id="test_c2_transactional_research",
+                name="C2 Transactional Research Profile",
+                role_aliases={"builder": "author"},
+                capability_tier=CapabilityTier.C2_REMOTE_BOUNDED,
+                permitted_effect_classes=frozenset({EffectClass.transactional}),
+            )
+            registry = ProfileRegistry()
+            registry.register(profile)
+
+            with patch("millstone.runtime.orchestrator.ProfileRegistry", return_value=registry):
+                orch = Orchestrator(
+                    tasklist="docs/tasklist.md",
+                    research=True,
+                    cli="claude",
+                    profile=profile.id,
+                )
             try:
                 # Inject a mock MCP tasklist provider with a known remote task ID
                 mock_mcp = MagicMock(spec=MCPTasklistProvider)
@@ -1994,7 +2010,18 @@ All done."""
         from millstone.artifact_providers.mcp import MCPTasklistProvider
         from millstone.artifacts.models import TasklistItem, TaskStatus
 
-        orch = Orchestrator(tasklist="docs/tasklist.md", quiet=True)
+        profile = Profile(
+            id="test_c2_transactional",
+            name="C2 Transactional Profile",
+            role_aliases={"builder": "author"},
+            capability_tier=CapabilityTier.C2_REMOTE_BOUNDED,
+            permitted_effect_classes=frozenset({EffectClass.transactional}),
+        )
+        registry = ProfileRegistry()
+        registry.register(profile)
+
+        with patch("millstone.runtime.orchestrator.ProfileRegistry", return_value=registry):
+            orch = Orchestrator(tasklist="docs/tasklist.md", profile=profile.id, quiet=True)
         try:
             mock_mcp = MagicMock(spec=MCPTasklistProvider)
             mock_mcp._agent_callback = None
@@ -2033,7 +2060,18 @@ All done."""
         from millstone.artifact_providers.mcp import MCPTasklistProvider
         from millstone.artifacts.models import TasklistItem, TaskStatus
 
-        orch = Orchestrator(tasklist="docs/tasklist.md", quiet=True)
+        profile = Profile(
+            id="test_c2_transactional_failure",
+            name="C2 Transactional Failure Profile",
+            role_aliases={"builder": "author"},
+            capability_tier=CapabilityTier.C2_REMOTE_BOUNDED,
+            permitted_effect_classes=frozenset({EffectClass.transactional}),
+        )
+        registry = ProfileRegistry()
+        registry.register(profile)
+
+        with patch("millstone.runtime.orchestrator.ProfileRegistry", return_value=registry):
+            orch = Orchestrator(tasklist="docs/tasklist.md", profile=profile.id, quiet=True)
         try:
             mock_mcp = MagicMock(spec=MCPTasklistProvider)
             mock_mcp._agent_callback = None
@@ -2065,6 +2103,47 @@ All done."""
                 assert orch.run_single_task() is False
 
             mock_mcp.update_task_status.assert_called_once_with("GH-42", TaskStatus.done)
+        finally:
+            orch.cleanup()
+
+    def test_run_single_task_skips_explicit_mcp_close_when_profile_disallows_remote_effects(
+        self, temp_repo
+    ):
+        """Default C1 profiles leave MCP completion to the builder prompt path."""
+        from millstone.artifact_providers.mcp import MCPTasklistProvider
+        from millstone.artifacts.models import TasklistItem, TaskStatus
+
+        orch = Orchestrator(tasklist="docs/tasklist.md", quiet=True)
+        try:
+            mock_mcp = MagicMock(spec=MCPTasklistProvider)
+            mock_mcp._agent_callback = None
+            task = TasklistItem(task_id="GH-42", title="Remote task", status=TaskStatus.todo)
+            mock_mcp.get_prompt_placeholders.return_value = {}
+            mock_mcp.list_tasks.return_value = [task]
+            mock_mcp.get_task.return_value = task
+            orch._outer_loop_manager.tasklist_provider = mock_mcp
+
+            def fake_run_agent(prompt, role="default", **kwargs):
+                if role == "author":
+                    (temp_repo / "impl.py").write_text("value = 1\n")
+                    return "Implemented remote task."
+                if role == "reviewer":
+                    return (
+                        '{"status":"APPROVED","review":"ok","summary":"ok",'
+                        '"findings":[],"findings_by_severity":{"critical":[],"high":[],'
+                        '"medium":[],"low":[],"nit":[]},"impossible_condition":null,'
+                        '"tasklist_fix_recommendation":null}'
+                    )
+                raise AssertionError(f"Unexpected role: {role}")
+
+            with (
+                patch.object(orch, "run_agent", side_effect=fake_run_agent),
+                patch.object(orch, "sanity_check_impl", return_value=True),
+                patch.object(orch, "delegate_commit", return_value=True),
+            ):
+                assert orch.run_single_task() is True
+
+            mock_mcp.update_task_status.assert_not_called()
         finally:
             orch.cleanup()
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -647,8 +647,8 @@ class TestParallelOrchestratorPhase1:
                 return "ok"
 
             worker.run_agent = fake_run_agent
-            worker.sanity_check_impl = lambda *_a, **_k: True
-            worker.sanity_check_review = lambda *_a, **_k: True
+            worker.sanity_check_impl = lambda *_a, **_k: None
+            worker.sanity_check_review = lambda *_a, **_k: None
             try:
                 blocked["seen"] = worker.run_single_task() is False
             finally:

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -184,3 +184,61 @@ class TestAcceptanceCriteria:
         mgr = TasklistManager(repo_dir=temp_repo)
         result = mgr.extract_current_task_acceptance_criteria()
         assert result == []
+
+
+class TestSingleTaskCompletionValidation:
+    def test_allows_first_unchecked_to_move_into_completed_summary(self, temp_repo):
+        mgr = TasklistManager(repo_dir=temp_repo)
+        original = (
+            "# Tasklist\n\n"
+            "## Completed\n\n"
+            "Earlier work is summarized here.\n\n"
+            "## Remaining\n\n"
+            "- [ ] Task 1\n"
+            "- [ ] Task 2\n"
+        )
+        new = (
+            "# Tasklist\n\n"
+            "## Completed\n\n"
+            "Earlier work is summarized here. Task 1 is now complete.\n\n"
+            "## Remaining\n\n"
+            "- [ ] Task 2\n"
+        )
+
+        valid, reason = mgr.validate_single_task_completion(original, new)
+
+        assert valid is True
+        assert reason == ""
+
+    def test_rejects_task_removal_without_completed_summary(self, temp_repo):
+        mgr = TasklistManager(repo_dir=temp_repo)
+        original = "# Tasklist\n\n- [ ] Task 1\n- [ ] Task 2\n"
+        new = "# Tasklist\n\n- [ ] Task 2\n"
+
+        valid, reason = mgr.validate_single_task_completion(original, new)
+
+        assert valid is False
+        assert "Task count decreased" in reason
+
+    def test_rejects_removing_later_task_from_completed_summary_mode(self, temp_repo):
+        mgr = TasklistManager(repo_dir=temp_repo)
+        original = (
+            "# Tasklist\n\n"
+            "## Completed\n\n"
+            "Earlier work is summarized here.\n\n"
+            "## Remaining\n\n"
+            "- [ ] Task 1\n"
+            "- [ ] Task 2\n"
+        )
+        new = (
+            "# Tasklist\n\n"
+            "## Completed\n\n"
+            "Earlier work is summarized here. Task 2 is now complete.\n\n"
+            "## Remaining\n\n"
+            "- [ ] Task 1\n"
+        )
+
+        valid, reason = mgr.validate_single_task_completion(original, new)
+
+        assert valid is False
+        assert "Task count decreased" in reason

--- a/tests/unit/test_sanity_advisory.py
+++ b/tests/unit/test_sanity_advisory.py
@@ -1,0 +1,150 @@
+"""Tests for advisory (non-blocking) sanity check behavior.
+
+Sanity checks return flag text (str) when concerns are found, or None when OK.
+They never halt the session or create STOP.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from millstone.loops.inner import InnerLoopManager
+
+
+@pytest.fixture
+def inner_loop(tmp_path: Path) -> InnerLoopManager:
+    work_dir = tmp_path / ".millstone"
+    work_dir.mkdir()
+    return InnerLoopManager(work_dir=work_dir, repo_dir=tmp_path)
+
+
+class TestSanityCheckImplAdvisory:
+    """Implementation sanity check returns flags instead of halting."""
+
+    def test_ok_returns_none(self, inner_loop: InnerLoopManager):
+        result = inner_loop.sanity_check_impl(
+            agent_output="Implemented the feature",
+            git_status="M src/foo.py",
+            git_diff="diff --git a/src/foo.py",
+            load_prompt_callback=lambda _: (
+                "{{ORCHESTRATOR_DIR}} {{AGENT_OUTPUT}} {{GIT_STATUS}} {{GIT_DIFF}}"
+            ),
+            run_agent_callback=lambda *_, **__: '{"status": "OK"}',
+        )
+        assert result is None
+
+    def test_halt_returns_flag_string(self, inner_loop: InnerLoopManager):
+        result = inner_loop.sanity_check_impl(
+            agent_output="asdfghjkl gibberish",
+            git_status="",
+            git_diff="",
+            load_prompt_callback=lambda _: (
+                "{{ORCHESTRATOR_DIR}} {{AGENT_OUTPUT}} {{GIT_STATUS}} {{GIT_DIFF}}"
+            ),
+            run_agent_callback=lambda *_, **__: (
+                '{"status": "HALT", "reason": "Output is incoherent"}'
+            ),
+        )
+        assert result == "Output is incoherent"
+
+    def test_halt_does_not_create_stop_file(self, inner_loop: InnerLoopManager):
+        inner_loop.sanity_check_impl(
+            agent_output="gibberish",
+            git_status="",
+            git_diff="",
+            load_prompt_callback=lambda _: (
+                "{{ORCHESTRATOR_DIR}} {{AGENT_OUTPUT}} {{GIT_STATUS}} {{GIT_DIFF}}"
+            ),
+            run_agent_callback=lambda *_, **__: '{"status": "HALT", "reason": "bad output"}',
+        )
+        stop_file = inner_loop.work_dir / "STOP.md"
+        assert not stop_file.exists()
+
+    def test_halt_without_reason_returns_default_message(self, inner_loop: InnerLoopManager):
+        result = inner_loop.sanity_check_impl(
+            agent_output="gibberish",
+            git_status="",
+            git_diff="",
+            load_prompt_callback=lambda _: (
+                "{{ORCHESTRATOR_DIR}} {{AGENT_OUTPUT}} {{GIT_STATUS}} {{GIT_DIFF}}"
+            ),
+            run_agent_callback=lambda *_, **__: '{"status": "HALT"}',
+        )
+        assert result is not None
+        assert "flagged" in result.lower() or "concern" in result.lower()
+
+    def test_legacy_stop_file_consumed_and_removed(self, inner_loop: InnerLoopManager):
+        """If an external tool creates STOP.md, it's read as a flag and removed."""
+        stop_file = inner_loop.work_dir / "STOP.md"
+        stop_file.write_text("External tool detected a problem")
+
+        result = inner_loop.sanity_check_impl(
+            agent_output="some output",
+            git_status="",
+            git_diff="",
+            load_prompt_callback=lambda _: (
+                "{{ORCHESTRATOR_DIR}} {{AGENT_OUTPUT}} {{GIT_STATUS}} {{GIT_DIFF}}"
+            ),
+            run_agent_callback=lambda *_, **__: '{"status": "OK"}',
+        )
+        assert "External tool detected a problem" in result
+        assert not stop_file.exists()
+
+
+class TestSanityCheckReviewAdvisory:
+    """Review sanity check returns flags instead of halting."""
+
+    def test_ok_returns_none(self, inner_loop: InnerLoopManager):
+        result = inner_loop.sanity_check_review(
+            review_output='{"status": "APPROVED", "review": "Looks good"}',
+            load_prompt_callback=lambda _: "{{ORCHESTRATOR_DIR}} {{REVIEW_OUTPUT}}",
+            run_agent_callback=lambda *_, **__: '{"status": "OK"}',
+        )
+        assert result is None
+
+    def test_halt_returns_flag_string(self, inner_loop: InnerLoopManager):
+        result = inner_loop.sanity_check_review(
+            review_output="totally incoherent review text",
+            load_prompt_callback=lambda _: "{{ORCHESTRATOR_DIR}} {{REVIEW_OUTPUT}}",
+            run_agent_callback=lambda *_, **__: (
+                '{"status": "HALT", "reason": "Review is incoherent"}'
+            ),
+        )
+        assert result == "Review is incoherent"
+
+    def test_halt_does_not_create_stop_file(self, inner_loop: InnerLoopManager):
+        inner_loop.sanity_check_review(
+            review_output="incoherent",
+            load_prompt_callback=lambda _: "{{ORCHESTRATOR_DIR}} {{REVIEW_OUTPUT}}",
+            run_agent_callback=lambda *_, **__: '{"status": "HALT", "reason": "bad review"}',
+        )
+        stop_file = inner_loop.work_dir / "STOP.md"
+        assert not stop_file.exists()
+
+    def test_legacy_stop_file_consumed_and_removed(self, inner_loop: InnerLoopManager):
+        stop_file = inner_loop.work_dir / "STOP.md"
+        stop_file.write_text("External review problem")
+
+        result = inner_loop.sanity_check_review(
+            review_output="some review",
+            load_prompt_callback=lambda _: "{{ORCHESTRATOR_DIR}} {{REVIEW_OUTPUT}}",
+            run_agent_callback=lambda *_, **__: '{"status": "OK"}',
+        )
+        assert "External review problem" in result
+        assert not stop_file.exists()
+
+
+class TestConsumeStopFile:
+    """_consume_stop_file reads, removes, and returns STOP.md content."""
+
+    def test_returns_none_when_no_file(self, inner_loop: InnerLoopManager):
+        assert inner_loop._consume_stop_file() is None
+
+    def test_returns_content_and_removes_file(self, inner_loop: InnerLoopManager):
+        stop_file = inner_loop.work_dir / "STOP.md"
+        stop_file.write_text("something went wrong")
+        result = inner_loop._consume_stop_file()
+        assert result == "something went wrong"
+        assert not stop_file.exists()


### PR DESCRIPTION
## Summary
- Sanity checks are now advisory instead of blocking — implementation sanity flags are injected into the reviewer prompt as context, and review sanity flags are surfaced in builder feedback as REQUEST_CHANGES
- No more premature session halts from false positive sanity checks

## Test plan
- [x] 11 unit tests for advisory sanity check behavior (`tests/unit/test_sanity_advisory.py`)
- [x] 6 E2E tests for end-to-end information flow (`tests/e2e/test_e2e_sanity_advisory.py`)
- [x] All 1882 existing tests pass
- [x] Lint, format, mypy, vulture all clean
- [x] Red/green verified: new tests fail against old code, pass against new

🤖 Generated with [Claude Code](https://claude.com/claude-code)