### PR TITLE
Release v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-04-07
+
+### Added
+- Dangerous pattern policy is now configurable per-pattern. Each pattern can specify `action = "block"` (halt the run) or `action = "flag"` (pass to reviewer as advisory context). A default action can be set for all patterns, with per-pattern overrides.
+- Dangerous pattern flags (action=flag) are merged with sanity check flags and injected into the reviewer prompt.
+- Backward compatible: legacy `block = true/false` config maps to `action = "block"/"flag"`.
+
 ## [0.6.5] - 2026-04-06
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.5"
+version = "0.6.6"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/millstone/config.py
+++ b/src/millstone/config.py
@@ -264,6 +264,45 @@ def resolve_loc_threshold(*limits: int | None) -> int | None:
     return min(enabled_limits)
 
 
+def normalize_dangerous_patterns(
+    patterns: list[str | dict],
+    default_action: str = "block",
+) -> list[dict[str, str]]:
+    """Normalize mixed-format dangerous patterns to uniform dicts.
+
+    Each entry in *patterns* may be a plain string (inherits *default_action*)
+    or a dict ``{"pattern": "...", "action": "block"|"flag"}``.
+
+    Returns a list of ``{"pattern": str, "action": str}`` dicts.
+    """
+    result: list[dict[str, str]] = []
+    for entry in patterns:
+        if isinstance(entry, str):
+            result.append({"pattern": entry, "action": default_action})
+        elif isinstance(entry, dict):
+            result.append(
+                {
+                    "pattern": entry["pattern"],
+                    "action": entry.get("action", default_action),
+                }
+            )
+    return result
+
+
+def resolve_dangerous_action(dangerous_section: dict) -> str:
+    """Resolve the default action from a dangerous policy section.
+
+    Supports both the new ``action`` key and the legacy ``block`` boolean.
+    ``action`` takes precedence when both are present.
+    """
+    if "action" in dangerous_section:
+        return dangerous_section["action"]
+    # Legacy: block=true → "block", block=false → "flag"
+    if dangerous_section.get("block", True):
+        return "block"
+    return "flag"
+
+
 def load_config(repo_dir: Path | None = None) -> dict:
     """Load configuration from .millstone/config.toml if it exists.
 

--- a/src/millstone/loops/inner.py
+++ b/src/millstone/loops/inner.py
@@ -12,7 +12,11 @@ import re
 from collections.abc import Callable
 from pathlib import Path
 
-from millstone.config import resolve_loc_threshold
+from millstone.config import (
+    normalize_dangerous_patterns,
+    resolve_dangerous_action,
+    resolve_loc_threshold,
+)
 from millstone.policy.schemas import (
     ReviewDecision,
     parse_review_decision,
@@ -58,6 +62,7 @@ class InnerLoopManager:
         self.policy = policy or {}
         self.project_config = project_config or {}
         self.loop_sensitive_patterns = loop_sensitive_patterns
+        self.dangerous_flags: str | None = None
 
     def git(self, *args) -> str:
         """Run git command and return output.
@@ -258,6 +263,7 @@ class InnerLoopManager:
         # Use callback or fall back to internal git method
         git = git_callback if git_callback else self.git
         skip_consumed = False
+        self.dangerous_flags = None
 
         # Check for changes (staged or unstaged)
         status = git("status", "--porcelain").strip()
@@ -373,18 +379,22 @@ class InnerLoopManager:
                         )
 
         # Check for dangerous patterns in diff content
-        dangerous_patterns = self.policy.get("dangerous", {}).get("patterns", [])
-        should_block = self.policy.get("dangerous", {}).get("block", True)
-        if dangerous_patterns:
-            # Get the actual diff content to scan for dangerous patterns
+        dangerous_section = self.policy.get("dangerous", {})
+        raw_patterns = dangerous_section.get("patterns", [])
+        default_action = resolve_dangerous_action(dangerous_section)
+        normalized = normalize_dangerous_patterns(raw_patterns, default_action)
+        if normalized:
             diff_content = git("diff", baseline)
-            for pattern in dangerous_patterns:
+            flag_reasons: list[str] = []
+            for entry in normalized:
+                pattern = entry["pattern"]
+                action = entry["action"]
                 if re.search(pattern, diff_content, re.IGNORECASE):
                     rule = f"dangerous.patterns (matched '{pattern}')"
                     self._log_policy_violation(
                         "dangerous_pattern", f"Diff content matched {rule}", log_callback
                     )
-                    if should_block:
+                    if action == "block":
                         print(
                             f"BLOCKED: Dangerous pattern detected in changes (policy rule: {rule})."
                         )
@@ -397,10 +407,15 @@ class InnerLoopManager:
                             save_state_callback(f"policy:dangerous_pattern:{pattern}")
                         return False, skip_consumed
                     else:
-                        # Log but don't block if block is False
-                        print(
-                            f"WARN: Dangerous pattern '{pattern}' detected (blocking disabled by policy)"
+                        # action == "flag": collect for reviewer
+                        flag_reasons.append(
+                            f"Dangerous pattern '{pattern}' detected in diff (flagged for review)"
                         )
+                        print(
+                            f"FLAG: Dangerous pattern '{pattern}' detected — flagging for reviewer"
+                        )
+            if flag_reasons:
+                self.dangerous_flags = "\n".join(flag_reasons)
 
         enforce_single_task = self.policy.get("tasklist", {}).get("enforce_single_task", False)
         if enforce_single_task and tasklist_path and tasklist_baseline is not None:

--- a/src/millstone/runtime/merge_pipeline.py
+++ b/src/millstone/runtime/merge_pipeline.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from millstone.artifacts.tasklist import TasklistManager
-from millstone.config import WORK_DIR_NAME, resolve_loc_threshold
+from millstone.config import (
+    WORK_DIR_NAME,
+    normalize_dangerous_patterns,
+    resolve_dangerous_action,
+    resolve_loc_threshold,
+)
 from millstone.runtime.locks import AdvisoryLock
 
 
@@ -65,13 +70,15 @@ def run_safety_gates(
 
     # Dangerous patterns
     dangerous = policy.get("dangerous", {})
-    dangerous_patterns = dangerous.get("patterns", []) or []
-    should_block = dangerous.get("block", True)
-    if dangerous_patterns and should_block:
+    raw_patterns = dangerous.get("patterns", []) or []
+    default_action = resolve_dangerous_action(dangerous)
+    normalized = normalize_dangerous_patterns(raw_patterns, default_action)
+    block_patterns = [e for e in normalized if e["action"] == "block"]
+    if block_patterns:
         diff_content = git("diff", diff_range)
-        for pattern in dangerous_patterns:
-            if re.search(pattern, diff_content, re.IGNORECASE):
-                return False, f"dangerous_pattern:{pattern}"
+        for entry in block_patterns:
+            if re.search(entry["pattern"], diff_content, re.IGNORECASE):
+                return False, f"dangerous_pattern:{entry['pattern']}"
 
     return True, ""
 

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -4250,6 +4250,12 @@ class Orchestrator:
             sanity_flags = self.sanity_check_impl(
                 artifact.output, artifact.git_status, artifact.git_diff
             )
+            # Merge dangerous pattern flags (from mechanical checks) with sanity flags
+            dangerous_flags = self._inner_loop_manager.dangerous_flags
+            if dangerous_flags:
+                sanity_flags = (
+                    f"{sanity_flags}\n\n{dangerous_flags}" if sanity_flags else dangerous_flags
+                )
             artifact.sanity_flags = sanity_flags
 
             return True, None

--- a/tests/e2e/test_e2e_sanity_advisory.py
+++ b/tests/e2e/test_e2e_sanity_advisory.py
@@ -1,12 +1,13 @@
-"""E2E tests for advisory sanity check → reviewer/builder information flow.
+"""E2E tests for advisory flags → reviewer/builder information flow.
 
-These tests verify that sanity check flags propagate correctly through the
-orchestrator pipeline rather than halting the session:
+These tests verify that sanity check and dangerous pattern flags propagate
+correctly through the orchestrator pipeline rather than halting the session:
 
 1. Impl sanity flags arrive in the reviewer prompt as advisory context.
 2. Review sanity flags arrive in the builder feedback text.
-3. The full flow continues (no halt) when sanity checks flag concerns.
-4. Clean sanity checks produce no flag artifacts in prompts.
+3. Dangerous pattern flags (action=flag) arrive in the reviewer prompt.
+4. The full flow continues (no halt) when flags are present.
+5. Clean checks produce no flag artifacts in prompts.
 """
 
 from __future__ import annotations
@@ -230,3 +231,105 @@ class TestFullFlowContinuesWithFlags:
             assert not (orch.work_dir / "STOP.md").exists()
         finally:
             orch.cleanup()
+
+
+class TestDangerousFlagsReachReviewer:
+    """Dangerous pattern flags (action=flag) are injected into the reviewer prompt."""
+
+    def test_flagged_dangerous_pattern_appears_in_reviewer_prompt(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """When a dangerous pattern with action=flag matches, the reviewer
+        prompt contains the flag in 'Automated Sanity Check Flags'."""
+        # Write policy with action=flag for DROP TABLE
+        policy_file = temp_repo / ".millstone" / "policy.toml"
+        policy_file.write_text(
+            "[limits]\nmax_loc_per_task = 10000\n\n"
+            '[dangerous]\naction = "flag"\n'
+            'patterns = ["DROP TABLE"]\n'
+        )
+
+        def _write_sql(repo: Path) -> None:
+            (repo / "migrate.sql").write_text("DROP TABLE old_users;\n")
+            subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=False)
+
+        stub_cli.add(role="author", output="Added migration.", side_effect=_write_sql)
+        stub_cli.add(role="sanity", output=_SANITY_OK_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+
+        reviewer_calls = [c for c in stub_cli.calls if c.role == "reviewer"]
+        assert reviewer_calls
+        reviewer_prompt = reviewer_calls[0].prompt
+
+        assert "Automated Sanity Check Flags" in reviewer_prompt
+        assert "DROP TABLE" in reviewer_prompt
+
+    def test_blocked_dangerous_pattern_still_halts(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """action=block dangerous patterns still halt — no regression."""
+        policy_file = temp_repo / ".millstone" / "policy.toml"
+        policy_file.write_text(
+            "[limits]\nmax_loc_per_task = 10000\n\n"
+            '[dangerous]\naction = "block"\n'
+            'patterns = ["DROP TABLE"]\n'
+        )
+
+        def _write_sql(repo: Path) -> None:
+            (repo / "migrate.sql").write_text("DROP TABLE old_users;\n")
+            subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=False)
+
+        stub_cli.add(role="author", output="Added migration.", side_effect=_write_sql)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        # Should halt — mechanical check blocks
+        assert exit_code == 1
+
+    def test_per_pattern_flag_override_reaches_reviewer(
+        self, stub_cli: StubCli, temp_repo: Path
+    ) -> None:
+        """Per-pattern action=flag overrides the default block action."""
+        policy_file = temp_repo / ".millstone" / "policy.toml"
+        policy_file.write_text(
+            "[limits]\nmax_loc_per_task = 10000\n\n"
+            '[dangerous]\naction = "block"\n'
+            '[[dangerous.patterns]]\npattern = "DROP TABLE"\naction = "flag"\n'
+        )
+
+        def _write_sql(repo: Path) -> None:
+            (repo / "migrate.sql").write_text("DROP TABLE old_users;\n")
+            subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=False)
+
+        stub_cli.add(role="author", output="Added migration.", side_effect=_write_sql)
+        stub_cli.add(role="sanity", output=_SANITY_OK_JSON)
+        stub_cli.add(role="reviewer", output=_APPROVED_JSON)
+        stub_cli.add(role="builder", output="Committed.", side_effect=_do_commit)
+
+        orch = Orchestrator(max_tasks=1)
+        try:
+            with stub_cli.patch(orch):
+                exit_code = orch.run()
+        finally:
+            orch.cleanup()
+
+        assert exit_code == 0
+
+        reviewer_calls = [c for c in stub_cli.calls if c.role == "reviewer"]
+        assert reviewer_calls
+        assert "DROP TABLE" in reviewer_calls[0].prompt

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -15219,11 +15219,11 @@ block = true
         finally:
             orch.cleanup()
 
-    def test_mechanical_checks_dangerous_patterns_warns_only(self, temp_repo, capsys):
-        """mechanical_checks warns but doesn't block when block=false."""
+    def test_mechanical_checks_dangerous_patterns_flags_only(self, temp_repo, capsys):
+        """mechanical_checks flags but doesn't block when block=false (legacy) or action=flag."""
         from millstone.runtime.orchestrator import POLICY_FILE_NAME, WORK_DIR_NAME
 
-        # Create policy with block=false
+        # Create policy with block=false (legacy compat → action=flag)
         config_dir = temp_repo / WORK_DIR_NAME
         config_dir.mkdir(exist_ok=True)
         policy_file = config_dir / POLICY_FILE_NAME
@@ -15243,10 +15243,10 @@ block = false
             subprocess.run(["git", "add", "."], cwd=temp_repo, capture_output=True)
 
             result = orch.mechanical_checks()
-            assert result is True  # Should pass since block=false
+            assert result is True  # Should pass since block=false → action=flag
 
             captured = capsys.readouterr()
-            assert "WARN" in captured.out
+            assert "FLAG" in captured.out
             assert "DROP TABLE" in captured.out
         finally:
             orch.cleanup()

--- a/tests/unit/test_dangerous_patterns.py
+++ b/tests/unit/test_dangerous_patterns.py
@@ -1,0 +1,368 @@
+"""Tests for configurable dangerous pattern policy.
+
+Users can:
+1. Add/remove patterns from the blocklist via policy.toml
+2. Set per-pattern action: "block" (halt) or "flag" (raise to reviewer)
+3. Set a default action for all patterns, override individually
+
+Config examples:
+
+    [dangerous]
+    action = "block"  # default for all patterns
+    patterns = [
+        "rm -rf",                                    # uses default action
+        {pattern = "DROP TABLE", action = "flag"},   # per-pattern override
+    ]
+
+Backward compat: `block = true` maps to action="block", `block = false` to action="flag".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from millstone.config import normalize_dangerous_patterns
+from millstone.loops.inner import InnerLoopManager
+
+
+@pytest.fixture
+def inner_loop(tmp_path: Path) -> InnerLoopManager:
+    work_dir = tmp_path / ".millstone"
+    work_dir.mkdir()
+    # Initialize a git repo so git commands work
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    return InnerLoopManager(work_dir=work_dir, repo_dir=tmp_path)
+
+
+def _make_diff(inner_loop: InnerLoopManager, content: str, filename: str = "script.sql") -> None:
+    """Create a file with given content and stage it."""
+    (inner_loop.repo_dir / filename).write_text(content)
+    subprocess.run(["git", "add", "."], cwd=inner_loop.repo_dir, capture_output=True, check=True)
+
+
+# =========================================================================
+# normalize_dangerous_patterns
+# =========================================================================
+
+
+class TestNormalizeDangerousPatterns:
+    """normalize_dangerous_patterns converts mixed config formats to uniform list."""
+
+    def test_plain_strings_use_default_action(self):
+        result = normalize_dangerous_patterns(
+            patterns=["rm -rf", "DROP TABLE"],
+            default_action="block",
+        )
+        assert result == [
+            {"pattern": "rm -rf", "action": "block"},
+            {"pattern": "DROP TABLE", "action": "block"},
+        ]
+
+    def test_plain_strings_use_flag_default(self):
+        result = normalize_dangerous_patterns(
+            patterns=["rm -rf"],
+            default_action="flag",
+        )
+        assert result == [{"pattern": "rm -rf", "action": "flag"}]
+
+    def test_dict_entries_preserve_per_pattern_action(self):
+        result = normalize_dangerous_patterns(
+            patterns=[
+                {"pattern": "DROP TABLE", "action": "flag"},
+                {"pattern": "rm -rf", "action": "block"},
+            ],
+            default_action="block",
+        )
+        assert result == [
+            {"pattern": "DROP TABLE", "action": "flag"},
+            {"pattern": "rm -rf", "action": "block"},
+        ]
+
+    def test_mixed_strings_and_dicts(self):
+        result = normalize_dangerous_patterns(
+            patterns=[
+                "rm -rf",
+                {"pattern": "DROP TABLE", "action": "flag"},
+                "force push",
+            ],
+            default_action="block",
+        )
+        assert result == [
+            {"pattern": "rm -rf", "action": "block"},
+            {"pattern": "DROP TABLE", "action": "flag"},
+            {"pattern": "force push", "action": "block"},
+        ]
+
+    def test_dict_without_action_uses_default(self):
+        result = normalize_dangerous_patterns(
+            patterns=[{"pattern": "DROP TABLE"}],
+            default_action="flag",
+        )
+        assert result == [{"pattern": "DROP TABLE", "action": "flag"}]
+
+    def test_empty_list(self):
+        result = normalize_dangerous_patterns(patterns=[], default_action="block")
+        assert result == []
+
+    def test_backward_compat_block_true(self):
+        """block=true in legacy config maps to action='block'."""
+        result = normalize_dangerous_patterns(
+            patterns=["rm -rf"],
+            default_action="block",  # caller resolves block=true → "block"
+        )
+        assert result[0]["action"] == "block"
+
+    def test_backward_compat_block_false(self):
+        """block=false in legacy config maps to action='flag'."""
+        result = normalize_dangerous_patterns(
+            patterns=["rm -rf"],
+            default_action="flag",  # caller resolves block=false → "flag"
+        )
+        assert result[0]["action"] == "flag"
+
+
+# =========================================================================
+# Mechanical checks integration
+# =========================================================================
+
+
+class TestDangerousPatternBlock:
+    """Patterns with action='block' halt the run."""
+
+    def test_block_action_halts(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "block",
+                "patterns": ["DROP TABLE"],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is False
+
+    def test_per_pattern_block_overrides_flag_default(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "flag",  # default is flag
+                "patterns": [
+                    {"pattern": "DROP TABLE", "action": "block"},  # but this one blocks
+                ],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is False
+
+
+class TestDangerousPatternFlag:
+    """Patterns with action='flag' pass mechanical checks but return flag text."""
+
+    def test_flag_action_passes_and_returns_flags(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "flag",
+                "patterns": ["DROP TABLE"],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is True
+        assert inner_loop.dangerous_flags is not None
+        assert "DROP TABLE" in inner_loop.dangerous_flags
+
+    def test_per_pattern_flag_overrides_block_default(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "block",  # default is block
+                "patterns": [
+                    {"pattern": "DROP TABLE", "action": "flag"},  # but this one flags
+                ],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is True
+        assert inner_loop.dangerous_flags is not None
+        assert "DROP TABLE" in inner_loop.dangerous_flags
+
+    def test_no_flags_when_no_match(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "flag",
+                "patterns": ["DROP TABLE"],
+            },
+        }
+        _make_diff(inner_loop, "SELECT * FROM users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is True
+        assert not inner_loop.dangerous_flags
+
+    def test_flags_cleared_between_checks(self, inner_loop: InnerLoopManager):
+        """dangerous_flags reset on each mechanical_checks call."""
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "flag",
+                "patterns": ["DROP TABLE"],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+        inner_loop.mechanical_checks(loc_baseline_ref=None, skip_mechanical_checks=False)
+        assert inner_loop.dangerous_flags
+
+        # Second call with clean diff
+        subprocess.run(
+            ["git", "add", "-A"], cwd=inner_loop.repo_dir, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "commit"],
+            cwd=inner_loop.repo_dir,
+            capture_output=True,
+            check=True,
+        )
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert not inner_loop.dangerous_flags
+
+
+class TestDangerousPatternMixed:
+    """Mixed block+flag patterns in same policy."""
+
+    def test_block_pattern_halts_even_with_flag_patterns(self, inner_loop: InnerLoopManager):
+        """If any block-action pattern matches, the run halts."""
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "patterns": [
+                    {"pattern": "DROP TABLE", "action": "flag"},
+                    {"pattern": "rm -rf", "action": "block"},
+                ],
+            },
+        }
+        _make_diff(inner_loop, "rm -rf /\nDROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is False
+
+    def test_only_flag_patterns_match_passes(self, inner_loop: InnerLoopManager):
+        """If only flag-action patterns match, the run passes with flags."""
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "patterns": [
+                    {"pattern": "DROP TABLE", "action": "flag"},
+                    {"pattern": "rm -rf", "action": "block"},
+                ],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is True
+        assert "DROP TABLE" in inner_loop.dangerous_flags
+
+
+class TestBackwardCompat:
+    """Legacy block=true/false config still works."""
+
+    def test_legacy_block_true_blocks(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "patterns": ["DROP TABLE"],
+                "block": True,
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is False
+
+    def test_legacy_block_false_flags(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "patterns": ["DROP TABLE"],
+                "block": False,
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;")
+
+        passed, _ = inner_loop.mechanical_checks(
+            loc_baseline_ref=None,
+            skip_mechanical_checks=False,
+        )
+        assert passed is True
+        assert inner_loop.dangerous_flags is not None
+        assert "DROP TABLE" in inner_loop.dangerous_flags
+
+
+class TestDangerousFlagsReachReviewer:
+    """dangerous_flags propagate to reviewer prompt via the orchestrator."""
+
+    # This is tested at the E2E level in test_e2e_sanity_advisory.py;
+    # here we verify the InnerLoopManager attribute contract.
+
+    def test_dangerous_flags_attribute_exists_after_init(self, inner_loop: InnerLoopManager):
+        assert inner_loop.dangerous_flags is None or inner_loop.dangerous_flags == ""
+
+    def test_dangerous_flags_populated_after_flag_match(self, inner_loop: InnerLoopManager):
+        inner_loop.policy = {
+            "limits": {"max_loc_per_task": 10000},
+            "dangerous": {
+                "action": "flag",
+                "patterns": ["DROP TABLE", "truncate table"],
+            },
+        }
+        _make_diff(inner_loop, "DROP TABLE users;\nTRUNCATE TABLE orders;")
+
+        inner_loop.mechanical_checks(loc_baseline_ref=None, skip_mechanical_checks=False)
+
+        # Both patterns should be in the flags
+        assert "DROP TABLE" in inner_loop.dangerous_flags
+        assert "truncate table" in inner_loop.dangerous_flags

--- a/tests/unit/test_dangerous_patterns.py
+++ b/tests/unit/test_dangerous_patterns.py
@@ -32,8 +32,20 @@ from millstone.loops.inner import InnerLoopManager
 def inner_loop(tmp_path: Path) -> InnerLoopManager:
     work_dir = tmp_path / ".millstone"
     work_dir.mkdir()
-    # Initialize a git repo so git commands work
+    # Initialize a git repo so git commands work (configure user for CI)
     subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
     subprocess.run(
         ["git", "commit", "--allow-empty", "-m", "init"],
         cwd=tmp_path,


### PR DESCRIPTION
## Summary
- Dangerous pattern policy is now configurable per-pattern with `action = "block"` or `action = "flag"`
- Flag-action patterns pass to the reviewer as advisory context instead of halting
- Per-pattern overrides: set a default action globally, override individually
- Backward compatible with legacy `block = true/false` config
- Dangerous flags merge with sanity check flags in the reviewer prompt

## Test plan
- [x] 20 unit tests for normalization, per-pattern actions, backward compat (`tests/unit/test_dangerous_patterns.py`)
- [x] 3 E2E tests for dangerous flags reaching reviewer, blocking still works, per-pattern override (`tests/e2e/test_e2e_sanity_advisory.py`)
- [x] 1905 total tests pass, lint/mypy/vulture clean
- [x] Red/green TDD: tests fail on import error before implementation, all pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)