### PR TITLE
Release v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-04-08
+
+### Fixed
+- `cleanup()` no longer deletes user-created files in `.millstone/`. Previously it removed everything except a hardcoded allowlist, silently destroying `policy.toml`, `project.toml`, and any user files. Now it only removes known transient files (`STOP.md`).
+
 ## [0.6.6] - 2026-04-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.6"
+version = "0.6.7"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -1669,44 +1669,18 @@ class Orchestrator:
         print()
 
     def cleanup(self):
-        """Remove work directory contents (but keep the directory, runs/, evals/, and tasks/)."""
-        import shutil
+        """Remove known transient files from work directory.
 
-        persistent = {
-            # Runtime history
-            "runs",
-            "evals",
-            "tasks",
-            "cycles",
-            "parallel",
-            "locks",
-            "worktrees",
-            # User-written config — never delete
-            "config.toml",
-            # Artifact files/dirs that are local-only by default
-            "opportunities.md",
-            "designs",
-            # Pause/resume state
-            "state.json",
-            # Always preserve the default tasklist regardless of which tasklist this
-            # Orchestrator instance was configured with.  Tests that pass a custom
-            # tasklist path (e.g. "my/tasks.md") must not delete the real
-            # .millstone/tasklist.md that exists on disk.
-            Path(DEFAULT_CONFIG["tasklist"]).name,
+        Only removes files that millstone itself creates as transient artifacts.
+        User-created files (config, policy, notes, etc.) are never touched.
+        """
+        transient_files = {
+            "STOP.md",
         }
-        # Also preserve a non-default tasklist name when it lives inside work_dir
-        if Path(self.tasklist).parts[0] == WORK_DIR_NAME:
-            persistent.add(Path(self.tasklist).name)
-        # Preserve a configured roadmap when it lives inside work_dir.
-        if self.roadmap and Path(self.roadmap).parts[0] == WORK_DIR_NAME:
-            persistent.add(Path(self.roadmap).name)
         if self.work_dir.exists():
-            for item in self.work_dir.iterdir():
-                if item.name in persistent:
-                    continue
-                if item.is_dir():
-                    shutil.rmtree(item)
-                else:
+            for name in transient_files:
+                item = self.work_dir / name
+                if item.exists():
                     item.unlink()
 
     def _get_provider(self, role: str = "default") -> CLIProvider:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -494,26 +494,26 @@ class TestOuterLoopManagerMaxCyclesPlumbing:
 
 
 class TestCleanup:
-    """Tests for cleanup behavior."""
+    """Tests for cleanup behavior.
 
-    def test_cleanup_removes_work_dir_contents(self, temp_repo):
-        """Cleanup removes contents but keeps work directory and runs/."""
+    cleanup() only removes known transient files (STOP.md).
+    All other files and directories are preserved.
+    """
+
+    def test_cleanup_preserves_user_files(self, temp_repo):
+        """Cleanup preserves user-created files and directories."""
         orch = Orchestrator()
         work_dir = orch.work_dir
 
-        # Create some files in work dir
         (work_dir / "test_file.txt").write_text("test")
         (work_dir / "subdir").mkdir()
         (work_dir / "subdir" / "nested.txt").write_text("nested")
 
         orch.cleanup()
 
-        # Directory should still exist; runs/ and tasklist.md are preserved
         assert work_dir.exists()
-        remaining = sorted(p.name for p in work_dir.iterdir())
-        assert "runs" in remaining, f"'runs' missing from {remaining}"
-        assert "test_file.txt" not in remaining, "Ephemeral file should be removed"
-        assert "subdir" not in remaining, "Ephemeral subdir should be removed"
+        assert (work_dir / "test_file.txt").exists()
+        assert (work_dir / "subdir" / "nested.txt").exists()
 
     def test_cleanup_is_idempotent(self, temp_repo):
         """Cleanup can be called multiple times safely."""
@@ -532,8 +532,6 @@ class TestCleanup:
             (work_dir / "parallel" / "keep.txt").write_text("x")
             (work_dir / "locks" / "keep.txt").write_text("x")
             (work_dir / "worktrees" / "keep.txt").write_text("x")
-            (work_dir / "tmp").mkdir(exist_ok=True)
-            (work_dir / "tmp" / "delete.txt").write_text("y")
 
             orch.cleanup()
 
@@ -543,7 +541,6 @@ class TestCleanup:
             assert (work_dir / "parallel" / "keep.txt").exists()
             assert (work_dir / "locks" / "keep.txt").exists()
             assert (work_dir / "worktrees" / "keep.txt").exists()
-            assert not (work_dir / "tmp").exists()
         finally:
             orch.cleanup()
 
@@ -561,15 +558,14 @@ class TestCleanup:
         finally:
             orch.cleanup()
 
-    def test_cleanup_still_removes_other_dirs(self, temp_repo):
-        """cleanup() still removes non-whitelisted work_dir contents."""
+    def test_cleanup_removes_transient_stop_file(self, temp_repo):
+        """cleanup() removes STOP.md (transient halt signal)."""
         orch = Orchestrator()
         work_dir = orch.work_dir
         try:
-            (work_dir / "junk").mkdir(exist_ok=True)
-            (work_dir / "junk" / "a.txt").write_text("junk")
+            (work_dir / "STOP.md").write_text("halted")
             orch.cleanup()
-            assert not (work_dir / "junk").exists()
+            assert not (work_dir / "STOP.md").exists()
         finally:
             orch.cleanup()
 
@@ -13261,15 +13257,10 @@ class TestCostTracking:
             tasks_dir = orch.work_dir / "tasks"
             assert tasks_dir.exists()
 
-            # Create a dummy file that should be cleaned
-            (orch.work_dir / "dummy.txt").write_text("test")
-
             orch.cleanup()
 
             # tasks directory should still exist
             assert tasks_dir.exists()
-            # But dummy file should be gone
-            assert not (orch.work_dir / "dummy.txt").exists()
         finally:
             pass  # cleanup already called
 

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,109 @@
+"""Tests for Orchestrator.cleanup() preserving user files.
+
+cleanup() must only remove known transient files — never user-created
+config or data files like policy.toml, project.toml, or unknown files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from millstone.runtime.orchestrator import Orchestrator
+
+
+class TestCleanupPreservesUserFiles:
+    """cleanup() must not delete user-created files."""
+
+    def test_preserves_policy_toml(self, temp_repo: Path) -> None:
+        orch = Orchestrator(max_tasks=1)
+        try:
+            policy_file = orch.work_dir / "policy.toml"
+            policy_file.write_text('[dangerous]\naction = "flag"\n')
+
+            orch.cleanup()
+
+            assert policy_file.exists(), "cleanup() deleted policy.toml"
+            assert policy_file.read_text() == '[dangerous]\naction = "flag"\n'
+        finally:
+            pass  # cleanup already ran
+
+    def test_preserves_project_toml(self, temp_repo: Path) -> None:
+        orch = Orchestrator(max_tasks=1)
+        try:
+            project_file = orch.work_dir / "project.toml"
+            project_file.write_text('[project]\nname = "myapp"\n')
+
+            orch.cleanup()
+
+            assert project_file.exists(), "cleanup() deleted project.toml"
+        finally:
+            pass
+
+    def test_preserves_unknown_user_files(self, temp_repo: Path) -> None:
+        """Files the user creates that millstone doesn't know about must survive."""
+        orch = Orchestrator(max_tasks=1)
+        try:
+            custom_file = orch.work_dir / "my_notes.md"
+            custom_file.write_text("Important notes")
+
+            orch.cleanup()
+
+            assert custom_file.exists(), "cleanup() deleted unknown user file"
+        finally:
+            pass
+
+    def test_preserves_unknown_user_directories(self, temp_repo: Path) -> None:
+        orch = Orchestrator(max_tasks=1)
+        try:
+            custom_dir = orch.work_dir / "my_scripts"
+            custom_dir.mkdir()
+            (custom_dir / "helper.sh").write_text("#!/bin/bash\necho hi")
+
+            orch.cleanup()
+
+            assert custom_dir.exists(), "cleanup() deleted unknown user directory"
+            assert (custom_dir / "helper.sh").exists()
+        finally:
+            pass
+
+
+class TestCleanupRemovesTransientFiles:
+    """cleanup() must still remove known transient artifacts."""
+
+    def test_removes_stop_file(self, temp_repo: Path) -> None:
+        orch = Orchestrator(max_tasks=1)
+        try:
+            stop_file = orch.work_dir / "STOP.md"
+            stop_file.write_text("halted")
+
+            orch.cleanup()
+
+            assert not stop_file.exists(), "cleanup() should remove STOP.md"
+        finally:
+            pass
+
+    def test_preserves_runs_directory(self, temp_repo: Path) -> None:
+        orch = Orchestrator(max_tasks=1)
+        try:
+            runs_dir = orch.work_dir / "runs"
+            runs_dir.mkdir(exist_ok=True)
+            (runs_dir / "20260408_120000.log").write_text("log content")
+
+            orch.cleanup()
+
+            assert runs_dir.exists()
+            assert (runs_dir / "20260408_120000.log").exists()
+        finally:
+            pass
+
+    def test_preserves_config_toml(self, temp_repo: Path) -> None:
+        orch = Orchestrator(max_tasks=1)
+        try:
+            config_file = orch.work_dir / "config.toml"
+            config_file.write_text("cli = 'claude'\n")
+
+            orch.cleanup()
+
+            assert config_file.exists(), "cleanup() deleted config.toml"
+        finally:
+            pass


### PR DESCRIPTION
## Summary
- `cleanup()` no longer deletes user-created files in `.millstone/`
- Only removes known transient files (`STOP.md`)
- Previously it removed everything except a hardcoded allowlist, silently destroying `policy.toml`, `project.toml`, and any user files

## Test plan
- [x] 7 unit tests for cleanup behavior (`tests/unit/test_cleanup.py`)
- [x] Updated existing cleanup tests to match new preserve-by-default behavior
- [x] 1912 total tests pass, lint/mypy/vulture clean
- [x] Red/green TDD: 4 tests failed before fix, all 7 pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)