### PR TITLE
Release v0.6.10: add beads artifact provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Key config options:
 - `review_designs` - Auto-review designs before planning
 - `cli` - Default CLI tool (`claude`, `codex`, `gemini`, or `opencode`)
 - `cli_builder`, `cli_reviewer`, `cli_sanity`, `cli_analyzer`, `cli_release_eng`, `cli_sre` - Per-role CLI overrides
+- `codex_yolo` - Opt in to passing `--yolo` to the Codex CLI provider
 - `opportunity_provider`, `design_provider`, `tasklist_provider` - Artifact backend selection (file/MCP-style providers)
 - `parallel_*` keys - Worktree/parallel execution controls
 - `profile` - Active role/profile registry mapping for loop contracts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-04-14
+
+### Changed
+- Codex CLI provider no longer passes `--yolo` by default. Users can now opt in explicitly with `--codex-yolo` or `codex_yolo = true` in `.millstone/config.toml`, and that setting is forwarded through parallel/worktree workers.
+
 ## [0.6.7] - 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.10] - 2026-04-25
+
+### Added
+- New `beads` artifact provider backed by the [beads](https://github.com/gastownhall/beads) graph issue tracker. Implements both `TasklistProvider` and `OpportunityProvider` via direct subprocess calls to the `bd` CLI — no LLM/MCP round-trip required. Configure via `tasklist_provider = "beads"` / `opportunity_provider = "beads"` in `.millstone/config.toml`. Supports label-based scoping (default `millstone-task` / `millstone-opportunity`) so tasks and opportunities coexist in one beads repo.
+- Tasks appended through the beads provider with an `opportunity_ref` set are automatically linked to their source opportunity via `bd dep add ... --type discovered-from`, preserving the build-from-opportunity relationship in the beads dependency graph.
+- New optional capability protocols `ReadyAwareTasklistProvider` (exposes `list_ready_tasks()` for backends with native dependency tracking) and `DependencyLinker` (exposes typed `link(from_id, to_id, kind)` for cross-artifact links). Both are `@runtime_checkable` and consumed via feature detection — providers without the capability remain fully supported through the base contracts.
+- New `DependencyKind` enum (`blocks`, `related`, `parent-child`, `discovered-from`) with values matching the beads CLI dependency-type vocabulary.
+
 ## [0.6.9] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.6.9] - 2026-04-14
+
+### Fixed
+- Codex structured-output resume commands now keep `--output-schema` ahead of the positional follow-up prompt, preventing Codex from misparsing schema-backed reviewer and sanity runs on resumed sessions.
+- Added regression coverage to lock down Codex structured-output command shapes for both resumed sessions and sanity-role executions.
+
 ## [0.6.8] - 2026-04-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ commit_designs = true        # stores at designs/
 commit_opportunities = true  # stores at opportunities.md
 ```
 
-For full multi-maintainer collaboration, use an external artifact provider (Jira, Linear, or GitHub Issues) instead of file-backed defaults.
+For full multi-maintainer collaboration, use an external artifact provider (Jira, Linear, GitHub Issues, or [beads](https://github.com/gastownhall/beads)) instead of file-backed defaults.
 
 ### Tasklist filter contract
 

--- a/docs/cli-providers/codex.md
+++ b/docs/cli-providers/codex.md
@@ -19,21 +19,27 @@ Codex reads `OPENAI_API_KEY` from the environment. Add it to your shell profile 
 ## Configure in millstone
 
 ```toml
-[millstone]
 cli = "codex"
+codex_yolo = true  # optional: pass --yolo to codex
 ```
 
 Or target a specific role — for example, using Codex only as the reviewer:
 
 ```toml
-[millstone]
 cli          = "claude"
 cli_reviewer = "codex"
 ```
 
+You can also opt into `--yolo` from the CLI when needed:
+
+```bash
+millstone --cli codex --codex-yolo
+```
+
 ## Notes
 
-- millstone invokes `codex exec - --yolo`, which runs Codex non-interactively and bypasses approval prompts. The prompt is delivered via stdin to avoid OS argument-size limits on large prompts.
+- millstone invokes `codex exec -` by default. Add `--codex-yolo` or set `codex_yolo = true` to pass Codex `--yolo` explicitly.
+- The prompt is delivered via stdin to avoid OS argument-size limits on large prompts.
 - Session resume uses `codex exec resume <session_id>`.
 - Structured output (reviewer and sanity check roles) uses `--output-schema <path>` with a JSON schema file written to `.millstone/`.
 

--- a/docs/cli-providers/index.md
+++ b/docs/cli-providers/index.md
@@ -18,7 +18,6 @@ millstone delegates all agent work — building, reviewing, sanity-checking, ana
 Set the CLI used for all roles in `.millstone/config.toml`:
 
 ```toml
-[millstone]
 cli = "claude"   # default
 ```
 
@@ -33,7 +32,6 @@ millstone --cli codex
 Different roles can use different CLIs. This is useful when one provider is better suited for review than build, or when you want to cross-check with a different model vendor:
 
 ```toml
-[millstone]
 cli          = "claude"    # default for any role not explicitly set
 cli_builder  = "claude"    # implements tasks
 cli_reviewer = "codex"     # reviews the builder's changes

--- a/docs/providers/beads.md
+++ b/docs/providers/beads.md
@@ -1,0 +1,97 @@
+# Beads provider
+
+Backs millstone's tasklist and opportunity artifacts with the [beads](https://github.com/gastownhall/beads) graph issue tracker. Unlike the MCP-based providers (Jira, Linear, GitHub), beads is invoked **directly via subprocess** — no LLM/MCP round-trip, no token cost, deterministic latency.
+
+---
+
+## Requirements
+
+- The `bd` CLI on `$PATH` (or set `bd_path` explicitly — see below).
+- A beads-initialized working tree (`bd init`).
+
+---
+
+## Configuration
+
+```toml
+[millstone]
+tasklist_provider    = "beads"
+opportunity_provider = "beads"
+
+[millstone.tasklist_provider_options]
+label   = "millstone-task"          # optional; recommended to namespace artifacts
+bd_path = "/usr/local/bin/bd"        # optional; default uses $PATH lookup
+
+[millstone.opportunity_provider_options]
+label   = "millstone-opportunity"    # default if omitted
+```
+
+The `label` option scopes each provider to its own slice of the beads repo. Tasks and opportunities can therefore coexist in a single beads database without overlapping reads.
+
+---
+
+## Identity model
+
+Beads assigns hash-based IDs (`bd-a1b2`) at creation time. When you call `append_tasks(...)` or `write_opportunity(...)`, the provider mutates the artifact's id field in place to the canonical bd id. Subsequent reads, updates, and links reference that id.
+
+---
+
+## Status mapping
+
+| millstone `TaskStatus` | beads status |
+|---|---|
+| `todo` | `open` |
+| `in_progress` | `in_progress` |
+| `done` | `closed` (set via `bd close`) |
+| `blocked` | `blocked` |
+
+| millstone `OpportunityStatus` | beads status |
+|---|---|
+| `identified` | `open` |
+| `adopted` | `in_progress` |
+| `rejected` | `closed` (set via `bd close`) |
+
+---
+
+## Dependency linking
+
+Both providers implement the optional `DependencyLinker` capability protocol:
+
+```python
+provider.link(from_id, to_id, DependencyKind.blocks)
+```
+
+Dependency kinds map to `bd dep add ... --type <kind>`:
+
+| `DependencyKind` | bd type |
+|---|---|
+| `blocks` | `blocks` |
+| `related` | `related` |
+| `parent_child` | `parent-child` |
+| `discovered_from` | `discovered-from` |
+
+When `append_tasks(...)` receives a task with `opportunity_ref` set, the provider automatically runs:
+
+```
+bd dep add <new-task-id> <opportunity-id> --type discovered-from
+```
+
+so the build-from-opportunity relationship is preserved in the beads graph. Link failures are logged but don't fail the append.
+
+---
+
+## Ready-task discovery
+
+`BeadsTasklistProvider` implements `ReadyAwareTasklistProvider`:
+
+```python
+provider.list_ready_tasks()  # → bd ready --json
+```
+
+This returns only unblocked tasks (the dependency graph is consulted server-side by beads). Callers can feature-detect with `isinstance(provider, ReadyAwareTasklistProvider)` and fall back to `list_tasks()` for providers that don't implement it.
+
+---
+
+## Snapshot / restore
+
+Snapshots store the set of current task ids; restore deletes any ids added since (`bd delete <id>`). Status changes and content edits made to pre-existing tasks are not reverted — beads' own history is the source of truth for those. This mirrors the scoped-rollback semantics used by the MCP provider.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -44,6 +44,7 @@ Credentials are managed entirely by the agent's MCP configuration — never stor
 | Backend | Description | Guide |
 |---------|-------------|-------|
 | `mcp` | Agent MCP tools for all reads and writes | [MCP](mcp.md) |
+| `beads` | Direct subprocess to the [beads](https://github.com/gastownhall/beads) `bd` CLI; native dependency graph + ready-task discovery | [Beads](beads.md) |
 | `file` | Local markdown files | — |
 
 ### Design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.7"
+version = "0.6.8"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.9"
+version = "0.6.10"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "millstone"
-version = "0.6.8"
+version = "0.6.9"
 description = "Orchestrator for agentic coding tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/millstone/agent_providers/implementations.py
+++ b/src/millstone/agent_providers/implementations.py
@@ -161,9 +161,6 @@ class CodexProvider(CLIProvider):
         if resume:
             # Resume an existing session
             cmd = ["codex", "exec", "resume", resume]
-            if prompt:
-                # Follow-up prompts are short enough to be safe as positional args.
-                cmd.append(prompt)
         else:
             # New session — use '-' so codex reads the prompt from stdin.
             cmd = ["codex", "exec", "-"]
@@ -178,6 +175,10 @@ class CodexProvider(CLIProvider):
 
             schema_path = get_schema_path(output_schema, schema_work_dir)
             cmd.extend(["--output-schema", schema_path])
+
+        if resume and prompt:
+            # Keep positional follow-up prompts last so codex still parses flags.
+            cmd.append(prompt)
 
         return cmd
 

--- a/src/millstone/agent_providers/implementations.py
+++ b/src/millstone/agent_providers/implementations.py
@@ -115,6 +115,9 @@ class ClaudeProvider(CLIProvider):
 class CodexProvider(CLIProvider):
     """Provider for Codex CLI (OpenAI)."""
 
+    def __init__(self, *, yolo: bool = False):
+        self.yolo = yolo
+
     @property
     def name(self) -> str:
         return "Codex CLI"
@@ -142,7 +145,7 @@ class CodexProvider(CLIProvider):
         """Build Codex CLI command.
 
         Codex uses:
-            codex exec - --yolo [--model <model>] [--output-schema <path>]
+            codex exec - [--yolo] [--model <model>] [--output-schema <path>]
 
         The prompt is always passed via stdin (using the '-' sentinel) to avoid
         hitting the OS execve argument-size limit (E2BIG / errno 7) on large
@@ -153,7 +156,7 @@ class CodexProvider(CLIProvider):
             codex exec resume <session_id> [<follow_up_prompt>]
 
         Note: --yolo bypasses approvals and sandboxing (equivalent to claude's
-        --dangerously-skip-permissions).
+        --dangerously-skip-permissions) and is opt-in via millstone config/CLI.
         """
         if resume:
             # Resume an existing session
@@ -163,7 +166,9 @@ class CodexProvider(CLIProvider):
                 cmd.append(prompt)
         else:
             # New session — use '-' so codex reads the prompt from stdin.
-            cmd = ["codex", "exec", "-", "--yolo"]
+            cmd = ["codex", "exec", "-"]
+            if self.yolo:
+                cmd.append("--yolo")
 
         if model:
             cmd.extend(["--model", model])

--- a/src/millstone/agent_providers/registry.py
+++ b/src/millstone/agent_providers/registry.py
@@ -16,12 +16,12 @@ PROVIDERS: dict[str, type[CLIProvider]] = {
 }
 
 
-def get_provider(name: str) -> CLIProvider:
+def get_provider(name: str, **kwargs) -> CLIProvider:
     """Get a CLI provider by name."""
     if name not in PROVIDERS:
         available = ", ".join(PROVIDERS.keys())
         raise ValueError(f"Unknown CLI provider: {name}. Available: {available}")
-    return PROVIDERS[name]()
+    return PROVIDERS[name](**kwargs)
 
 
 def list_providers() -> list[str]:

--- a/src/millstone/artifact_providers/__init__.py
+++ b/src/millstone/artifact_providers/__init__.py
@@ -6,8 +6,10 @@ from millstone.artifact_providers.base import (
     TasklistProviderBase,
 )
 from millstone.artifact_providers.protocols import (
+    DependencyLinker,
     DesignProvider,
     OpportunityProvider,
+    ReadyAwareTasklistProvider,
     TasklistProvider,
 )
 from millstone.artifact_providers.registry import (
@@ -26,10 +28,12 @@ from millstone.artifact_providers.registry import (
 )
 
 __all__ = [
+    "DependencyLinker",
     "DesignProvider",
     "DesignProviderBase",
     "OpportunityProvider",
     "OpportunityProviderBase",
+    "ReadyAwareTasklistProvider",
     "TasklistProvider",
     "TasklistProviderBase",
     "get_design_provider",

--- a/src/millstone/artifact_providers/beads.py
+++ b/src/millstone/artifact_providers/beads.py
@@ -1,0 +1,493 @@
+"""Beads-backed artifact providers (subprocess-based).
+
+Implements ``BeadsTasklistProvider`` and ``BeadsOpportunityProvider`` against
+the ``bd`` CLI from https://github.com/gastownhall/beads. Beads is a
+distributed graph issue tracker — millstone uses it as a deterministic remote
+backend, calling ``bd`` directly rather than going through an LLM/MCP loop.
+
+Configuration (``.millstone/config.toml``)::
+
+    [millstone]
+    tasklist_provider = "beads"
+    opportunity_provider = "beads"
+
+    [tasklist_provider_options]
+    label = "millstone-task"   # optional filter; recommended to namespace artifacts
+    bd_path = "/usr/local/bin/bd"  # optional override; default uses $PATH lookup
+
+    [opportunity_provider_options]
+    label = "millstone-opportunity"
+
+The ``bd`` binary must be on ``PATH`` (or ``bd_path`` set), and the working
+directory must be a beads-initialized repo (``bd init``).
+
+Both providers implement the optional ``ReadyAwareTasklistProvider`` /
+``DependencyLinker`` capability protocols. Tasks appended with an
+``opportunity_ref`` set are auto-linked to the referenced opportunity via
+``bd dep add ... --type discovered-from``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from millstone.artifact_providers.base import (
+    OpportunityProviderBase,
+    TasklistProviderBase,
+)
+from millstone.artifact_providers.registry import (
+    register_opportunity_provider_class,
+    register_tasklist_provider_class,
+)
+from millstone.artifacts.models import (
+    DependencyKind,
+    Opportunity,
+    OpportunityStatus,
+    TasklistItem,
+    TaskStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Status mapping: TaskStatus / OpportunityStatus <-> beads status strings.
+_TASK_STATUS_TO_BD: dict[TaskStatus, str] = {
+    TaskStatus.todo: "open",
+    TaskStatus.in_progress: "in_progress",
+    TaskStatus.done: "closed",
+    TaskStatus.blocked: "blocked",
+}
+
+_BD_TO_TASK_STATUS: dict[str, TaskStatus] = {
+    "open": TaskStatus.todo,
+    "ready": TaskStatus.todo,
+    "in_progress": TaskStatus.in_progress,
+    "closed": TaskStatus.done,
+    "done": TaskStatus.done,
+    "blocked": TaskStatus.blocked,
+}
+
+_OPP_STATUS_TO_BD: dict[OpportunityStatus, str] = {
+    OpportunityStatus.identified: "open",
+    OpportunityStatus.adopted: "in_progress",
+    OpportunityStatus.rejected: "closed",
+}
+
+_BD_TO_OPP_STATUS: dict[str, OpportunityStatus] = {
+    "open": OpportunityStatus.identified,
+    "ready": OpportunityStatus.identified,
+    "in_progress": OpportunityStatus.adopted,
+    "closed": OpportunityStatus.rejected,
+    "done": OpportunityStatus.rejected,
+}
+
+
+class BeadsCLIError(RuntimeError):
+    """Raised when a `bd` invocation fails."""
+
+
+class _BeadsCLI:
+    """Thin wrapper around `bd` invocations. Injectable for tests."""
+
+    def __init__(self, bd_path: str | None = None, cwd: Path | None = None) -> None:
+        resolved = bd_path or shutil.which("bd")
+        if not resolved:
+            raise BeadsCLIError(
+                "beads CLI ('bd') not found on PATH. "
+                "Install from https://github.com/gastownhall/beads or set "
+                "bd_path in [tasklist_provider_options]."
+            )
+        self.bd_path = resolved
+        self.cwd = cwd
+
+    def run(self, args: list[str], *, json_output: bool = False) -> str:
+        """Invoke `bd` with the given args; return stdout. Raises BeadsCLIError on failure."""
+        cmd = [self.bd_path]
+        if json_output:
+            cmd.append("--json")
+        cmd.extend(args)
+        try:
+            result = subprocess.run(  # noqa: S603 — bd_path resolved via which()
+                cmd,
+                cwd=str(self.cwd) if self.cwd else None,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            raise BeadsCLIError(f"failed to invoke bd: {exc}") from exc
+        if result.returncode != 0:
+            raise BeadsCLIError(
+                f"bd {' '.join(args)} failed (exit {result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return result.stdout
+
+    def run_json(self, args: list[str]) -> Any:
+        """Invoke `bd --json ...` and parse the JSON result."""
+        out = self.run(args, json_output=True).strip()
+        if not out:
+            return None
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError as exc:
+            raise BeadsCLIError(
+                f"bd {' '.join(args)} returned non-JSON output: {out[:200]!r}"
+            ) from exc
+
+
+def _coerce_items(payload: Any) -> list[dict]:
+    """Normalize bd JSON list output to a list of issue dicts.
+
+    Different bd subcommands wrap the array under different keys
+    (`issues`, `items`, `results`); fall back to top-level list.
+    """
+    if payload is None:
+        return []
+    if isinstance(payload, list):
+        return [x for x in payload if isinstance(x, dict)]
+    if isinstance(payload, dict):
+        for key in ("issues", "items", "results", "data"):
+            if key in payload and isinstance(payload[key], list):
+                return [x for x in payload[key] if isinstance(x, dict)]
+        # Single issue object
+        if "id" in payload:
+            return [payload]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# BeadsTasklistProvider
+# ---------------------------------------------------------------------------
+
+
+class BeadsTasklistProvider(TasklistProviderBase):
+    """Tasklist provider backed by the beads CLI.
+
+    Implements ``ReadyAwareTasklistProvider`` and ``DependencyLinker`` capabilities.
+
+    Notes on identity: beads assigns hash-based IDs (``bd-a1b2``) at creation
+    time. ``append_tasks`` mutates each ``TasklistItem.task_id`` in place to the
+    beads-assigned ID after creation, so subsequent reads / updates use the
+    canonical ID.
+    """
+
+    def __init__(
+        self,
+        *,
+        label: str | None = None,
+        bd_path: str | None = None,
+        cwd: Path | None = None,
+        cli: _BeadsCLI | None = None,
+    ) -> None:
+        self._label = label
+        self._cli = cli or _BeadsCLI(bd_path=bd_path, cwd=cwd)
+
+    @classmethod
+    def from_config(cls, options: dict[str, Any]) -> BeadsTasklistProvider:
+        return cls(
+            label=options.get("label"),
+            bd_path=options.get("bd_path"),
+            cwd=Path(options["cwd"]) if options.get("cwd") else None,
+        )
+
+    # -- read --------------------------------------------------------------
+
+    def _list_args(self) -> list[str]:
+        args = ["list", "--status", "open,in_progress,blocked"]
+        if self._label:
+            args.extend(["--label", self._label])
+        return args
+
+    def list_tasks(self) -> list[TasklistItem]:
+        payload = self._cli.run_json(self._list_args())
+        return [self._to_item(d) for d in _coerce_items(payload)]
+
+    def list_ready_tasks(self) -> list[TasklistItem]:
+        """Return only unblocked tasks (uses ``bd ready``)."""
+        args = ["ready"]
+        if self._label:
+            args.extend(["--label", self._label])
+        payload = self._cli.run_json(args)
+        return [self._to_item(d) for d in _coerce_items(payload)]
+
+    def get_task(self, task_id: str) -> TasklistItem | None:
+        try:
+            payload = self._cli.run_json(["show", task_id])
+        except BeadsCLIError:
+            return None
+        items = _coerce_items(payload)
+        return self._to_item(items[0]) if items else None
+
+    @staticmethod
+    def _to_item(d: dict) -> TasklistItem:
+        raw_status = str(d.get("status") or "open").lower().strip()
+        status = _BD_TO_TASK_STATUS.get(raw_status, TaskStatus.todo)
+        return TasklistItem(
+            task_id=str(d["id"]),
+            title=str(d.get("title") or d.get("summary") or ""),
+            status=status,
+            raw=str(d.get("description") or d.get("body") or "") or None,
+        )
+
+    # -- write -------------------------------------------------------------
+
+    def append_tasks(self, tasks: list[TasklistItem]) -> None:
+        for task in tasks:
+            task.validate()
+            new_id = self._create(task)
+            # Mutate to beads-assigned ID so callers / subsequent reads match.
+            task.task_id = new_id
+            if task.opportunity_ref:
+                # Best-effort: link new task to its source opportunity.
+                try:
+                    self.link(new_id, task.opportunity_ref, DependencyKind.discovered_from)
+                except BeadsCLIError as exc:
+                    logger.warning(
+                        "failed to link beads task %s -> opportunity %s: %s",
+                        new_id,
+                        task.opportunity_ref,
+                        exc,
+                    )
+
+    def _create(self, task: TasklistItem) -> str:
+        args = ["create", task.title, "-t", "task"]
+        if self._label:
+            args.extend(["-l", self._label])
+        description = _format_task_body(task)
+        if description:
+            args.extend(["-d", description])
+        payload = self._cli.run_json(args)
+        items = _coerce_items(payload)
+        if not items or "id" not in items[0]:
+            raise BeadsCLIError(f"bd create did not return an id for task {task.title!r}")
+        return str(items[0]["id"])
+
+    def update_task(self, task: TasklistItem) -> None:
+        task.validate()
+        body = _format_task_body(task)
+        args = ["update", task.task_id, "--title", task.title]
+        if body:
+            args.extend(["--description", body])
+        bd_status = _TASK_STATUS_TO_BD.get(task.status)
+        if bd_status:
+            args.extend(["--status", bd_status])
+        self._cli.run(args)
+
+    def update_task_status(self, task_id: str, status: TaskStatus) -> None:
+        bd_status = _TASK_STATUS_TO_BD.get(status)
+        if bd_status is None:
+            raise ValueError(f"unsupported task status for beads: {status}")
+        if status == TaskStatus.done:
+            self._cli.run(["close", task_id])
+        else:
+            self._cli.run(["update", task_id, "--status", bd_status])
+
+    # -- snapshot / restore -----------------------------------------------
+
+    def get_snapshot(self) -> str:
+        """Snapshot = JSON list of current task ids. Used for scoped rollback."""
+        ids = sorted(t.task_id for t in self.list_tasks())
+        return json.dumps({"task_ids": ids})
+
+    def restore_snapshot(self, content: str) -> None:
+        """Delete tasks added since the snapshot was taken.
+
+        Mirrors the MCP provider's scoped-rollback semantics: only newly added
+        tasks are removed; status/content edits to pre-existing tasks are not
+        reverted (beads' own history is the source of truth for those).
+        """
+        try:
+            baseline = set(json.loads(content).get("task_ids") or [])
+        except (json.JSONDecodeError, AttributeError) as exc:
+            raise ValueError(f"invalid beads snapshot: {exc}") from exc
+        current = {t.task_id for t in self.list_tasks()}
+        for task_id in current - baseline:
+            try:
+                self._cli.run(["delete", task_id])
+            except BeadsCLIError as exc:
+                logger.warning("failed to delete beads task %s on rollback: %s", task_id, exc)
+
+    # -- DependencyLinker capability --------------------------------------
+
+    def link(self, from_id: str, to_id: str, kind: DependencyKind) -> None:
+        """Add a typed link between two beads issues via ``bd dep add``.
+
+        Semantics follow the kind: for ``blocks``, ``from_id`` blocks ``to_id``;
+        for ``discovered_from``, ``from_id`` was discovered while working on
+        ``to_id``; etc.
+        """
+        self._cli.run(["dep", "add", from_id, to_id, "--type", kind.value])
+
+    # -- prompt placeholders ----------------------------------------------
+
+    def get_prompt_placeholders(self) -> dict[str, str]:
+        label_clause = f" with label '{self._label}'" if self._label else ""
+        return {
+            "TASKLIST_READ_INSTRUCTIONS": (
+                f"Use the beads CLI: `bd ready --json`{(' --label ' + self._label) if self._label else ''}"
+                f" to list unblocked tasks{label_clause}. "
+                "Pick the first item; use `bd show <id>` for full details."
+            ),
+            "TASKLIST_COMPLETE_INSTRUCTIONS": (
+                "Mark the task done with `bd close <id>`. Do not modify other issues."
+            ),
+            "TASKLIST_APPEND_INSTRUCTIONS": (
+                f'Create new beads tasks with `bd create "<title>" -t task'
+                f'{(" -l " + self._label) if self._label else ""} -d "<body>"`.'
+            ),
+            "TASKLIST_UPDATE_INSTRUCTIONS": (
+                "Edit existing tasks in place via `bd update <id> --title/--description/--status`. "
+                "Do not create duplicates."
+            ),
+            "TASKLIST_REWRITE_INSTRUCTIONS": (
+                "For bulk updates, iterate the compacted list and `bd update <id>` each entry."
+            ),
+        }
+
+
+def _format_task_body(task: TasklistItem) -> str:
+    """Render TasklistItem metadata into a beads description body."""
+    lines: list[str] = []
+    if task.opportunity_ref:
+        lines.append(f"Opportunity: {task.opportunity_ref}")
+    if task.design_ref:
+        lines.append(f"Design: {task.design_ref}")
+    if task.context:
+        lines.append(f"Context: {task.context}")
+    if task.criteria:
+        lines.append(f"Criteria: {task.criteria}")
+    if task.tests:
+        lines.append(f"Tests: {task.tests}")
+    if task.risk:
+        lines.append(f"Risk: {task.risk}")
+    if task.acceptance_criteria:
+        lines.append("Acceptance criteria:")
+        lines.extend(f"- {c}" for c in task.acceptance_criteria)
+    if task.raw and not lines:
+        return task.raw
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# BeadsOpportunityProvider
+# ---------------------------------------------------------------------------
+
+
+class BeadsOpportunityProvider(OpportunityProviderBase):
+    """Opportunity provider backed by beads.
+
+    Treats opportunities as beads issues with a configurable label
+    (default: ``millstone-opportunity``) so they can coexist with tasks in the
+    same backend without overlap.
+
+    Implements ``DependencyLinker`` for cross-artifact linking.
+    """
+
+    def __init__(
+        self,
+        *,
+        label: str | None = "millstone-opportunity",
+        bd_path: str | None = None,
+        cwd: Path | None = None,
+        cli: _BeadsCLI | None = None,
+    ) -> None:
+        self._label = label
+        self._cli = cli or _BeadsCLI(bd_path=bd_path, cwd=cwd)
+
+    @classmethod
+    def from_config(cls, options: dict[str, Any]) -> BeadsOpportunityProvider:
+        return cls(
+            label=options.get("label", "millstone-opportunity"),
+            bd_path=options.get("bd_path"),
+            cwd=Path(options["cwd"]) if options.get("cwd") else None,
+        )
+
+    # -- read --------------------------------------------------------------
+
+    def list_opportunities(self) -> list[Opportunity]:
+        args = ["list"]
+        if self._label:
+            args.extend(["--label", self._label])
+        payload = self._cli.run_json(args)
+        return [self._to_opp(d) for d in _coerce_items(payload)]
+
+    def get_opportunity(self, opportunity_id: str) -> Opportunity | None:
+        try:
+            payload = self._cli.run_json(["show", opportunity_id])
+        except BeadsCLIError:
+            return None
+        items = _coerce_items(payload)
+        return self._to_opp(items[0]) if items else None
+
+    @staticmethod
+    def _to_opp(d: dict) -> Opportunity:
+        raw_status = str(d.get("status") or "open").lower().strip()
+        status = _BD_TO_OPP_STATUS.get(raw_status, OpportunityStatus.identified)
+        description = str(d.get("description") or d.get("body") or "").strip() or "(no description)"
+        return Opportunity(
+            opportunity_id=str(d["id"]),
+            title=str(d.get("title") or d.get("summary") or ""),
+            status=status,
+            description=description,
+            raw=description,
+        )
+
+    # -- write -------------------------------------------------------------
+
+    def write_opportunity(self, opportunity: Opportunity) -> None:
+        opportunity.validate()
+        # Beads assigns its own ID; replace the caller's slug with it.
+        args = ["create", opportunity.title, "-t", "task"]
+        if self._label:
+            args.extend(["-l", self._label])
+        if opportunity.description:
+            args.extend(["-d", opportunity.description])
+        if opportunity.priority:
+            args.extend(["-p", str(opportunity.priority)])
+        payload = self._cli.run_json(args)
+        items = _coerce_items(payload)
+        if not items or "id" not in items[0]:
+            raise BeadsCLIError(
+                f"bd create did not return an id for opportunity {opportunity.title!r}"
+            )
+        opportunity.opportunity_id = str(items[0]["id"])
+
+    def update_opportunity_status(self, opportunity_id: str, status: OpportunityStatus) -> None:
+        bd_status = _OPP_STATUS_TO_BD.get(status)
+        if bd_status is None:
+            raise ValueError(f"unsupported opportunity status for beads: {status}")
+        if status == OpportunityStatus.rejected:
+            self._cli.run(["close", opportunity_id])
+        else:
+            self._cli.run(["update", opportunity_id, "--status", bd_status])
+
+    # -- DependencyLinker capability --------------------------------------
+
+    def link(self, from_id: str, to_id: str, kind: DependencyKind) -> None:
+        self._cli.run(["dep", "add", from_id, to_id, "--type", kind.value])
+
+    # -- prompt placeholders ----------------------------------------------
+
+    def get_prompt_placeholders(self) -> dict[str, str]:
+        label_clause = f" -l {self._label}" if self._label else ""
+        return {
+            "OPPORTUNITY_READ_INSTRUCTIONS": (
+                f"List opportunities with `bd list{label_clause} --json`. "
+                "Use `bd show <id>` for full details."
+            ),
+            "OPPORTUNITY_WRITE_INSTRUCTIONS": (
+                f'Create opportunities with `bd create "<title>" -t task{label_clause} '
+                '-d "<description>" -p <priority>`.'
+            ),
+        }
+
+
+# Self-register at import time.
+register_tasklist_provider_class("beads", BeadsTasklistProvider)
+register_opportunity_provider_class("beads", BeadsOpportunityProvider)

--- a/src/millstone/artifact_providers/protocols.py
+++ b/src/millstone/artifact_providers/protocols.py
@@ -11,6 +11,7 @@ contracts in ``millstone.artifact_providers.base``.
 from typing import Protocol, runtime_checkable
 
 from millstone.artifacts.models import (
+    DependencyKind,
     Design,
     DesignStatus,
     Opportunity,
@@ -48,3 +49,28 @@ class TasklistProvider(Protocol):
     def get_snapshot(self) -> str: ...
     def restore_snapshot(self, content: str) -> None: ...
     def get_prompt_placeholders(self) -> dict[str, str]: ...
+
+
+@runtime_checkable
+class ReadyAwareTasklistProvider(Protocol):
+    """Optional capability: provider can return only unblocked / ready-to-work tasks.
+
+    Backends that natively model dependencies (e.g. beads) can answer this
+    cheaply. Callers should use ``isinstance(provider, ReadyAwareTasklistProvider)``
+    to feature-detect; for providers that do not implement it, fall back to
+    ``list_tasks()``.
+    """
+
+    def list_ready_tasks(self) -> list[TasklistItem]: ...
+
+
+@runtime_checkable
+class DependencyLinker(Protocol):
+    """Optional capability: provider can record typed links between two artifact ids.
+
+    Implemented by providers whose backend stores a dependency graph (e.g. beads
+    via ``bd dep add``). The semantics of ``from_id`` / ``to_id`` follow the
+    given ``DependencyKind`` (e.g. for ``blocks``, ``from_id`` blocks ``to_id``).
+    """
+
+    def link(self, from_id: str, to_id: str, kind: DependencyKind) -> None: ...

--- a/src/millstone/artifacts/models.py
+++ b/src/millstone/artifacts/models.py
@@ -40,6 +40,19 @@ class TaskStatus(str, Enum):
     blocked = "blocked"
 
 
+class DependencyKind(str, Enum):
+    """Typed link between two artifact ids, for providers that support them.
+
+    Values match the canonical names used by the beads CLI (`bd dep add ... --type`).
+    Providers without dependency support simply do not implement DependencyLinker.
+    """
+
+    blocks = "blocks"
+    related = "related"
+    parent_child = "parent-child"
+    discovered_from = "discovered-from"
+
+
 @dataclass
 class Opportunity:
     opportunity_id: str  # canonical identity (explicit ID field, else title slug)

--- a/src/millstone/config.py
+++ b/src/millstone/config.py
@@ -167,6 +167,7 @@ DEFAULT_CONFIG = {
     "cli_analyzer": None,  # CLI for complexity analysis role
     "cli_release_eng": None,  # CLI for release engineering role
     "cli_sre": None,  # CLI for site reliability engineering role
+    "codex_yolo": False,  # Opt into codex --yolo (approval/sandbox bypass)
     # Session mode: how sessions persist across tasks
     # "new_each_task" - Fresh session for each task (default, safest)
     # "continue_within_run" - Preserve session for all tasks in single invocation

--- a/src/millstone/loops/outer.py
+++ b/src/millstone/loops/outer.py
@@ -47,6 +47,8 @@ with contextlib.suppress(Exception):
     import millstone.artifact_providers.mcp  # noqa: F401  (side-effect: registers "mcp" backends)
 with contextlib.suppress(Exception):
     import millstone.artifact_providers.jira  # noqa: F401  (side-effect: registers "jira" backend)
+with contextlib.suppress(Exception):
+    import millstone.artifact_providers.beads  # noqa: F401  (side-effect: registers "beads" backend)
 
 if TYPE_CHECKING:
     # Avoid circular import - only used for type hints

--- a/src/millstone/runtime/orchestrator.py
+++ b/src/millstone/runtime/orchestrator.py
@@ -377,6 +377,7 @@ class Orchestrator:
         cli_analyzer: str | None = None,
         cli_release_eng: str | None = None,
         cli_sre: str | None = None,
+        codex_yolo: bool = False,
         # Worktree/parallel execution (control plane)
         parallel_enabled: bool = False,
         parallel_concurrency: int = 1,
@@ -579,6 +580,7 @@ class Orchestrator:
         self._cli_analyzer = cli_analyzer or cli
         self._cli_release_eng = cli_release_eng or cli
         self._cli_sre = cli_sre or cli
+        self._codex_yolo = codex_yolo
         # Cache for instantiated providers (lazy-loaded)
         self._providers: dict[str, CLIProvider] = {}
 
@@ -1717,7 +1719,8 @@ class Orchestrator:
 
         # Return cached provider or create new one
         if cli_name not in self._providers:
-            self._providers[cli_name] = get_provider(cli_name)
+            provider_kwargs = {"yolo": self._codex_yolo} if cli_name == "codex" else {}
+            self._providers[cli_name] = get_provider(cli_name, **provider_kwargs)
         return self._providers[cli_name]
 
     def _is_run_claude_patched(self) -> bool:
@@ -5377,6 +5380,13 @@ Remote backlog scoping (Jira / Linear / GitHub):
         f"Available: {available_clis}.",
     )
     parser.add_argument(
+        "--codex-yolo",
+        action="store_true",
+        default=bool(config.get("codex_yolo", False)),
+        help="Pass --yolo to Codex CLI invocations. Opt-in only because it bypasses "
+        "Codex approval prompts and sandboxing.",
+    )
+    parser.add_argument(
         "--compact-threshold",
         type=int,
         default=config["compact_threshold"],
@@ -6003,6 +6013,7 @@ Remote backlog scoping (Jira / Linear / GitHub):
                 cli_reviewer=args.cli_reviewer,
                 cli_sanity=args.cli_sanity,
                 cli_analyzer=args.cli_analyzer,
+                codex_yolo=args.codex_yolo,
                 log_verbosity=log_verbosity,
                 log_diff_mode=log_diff_mode,
                 verbose_header=verbose_header,
@@ -6026,6 +6037,7 @@ Remote backlog scoping (Jira / Linear / GitHub):
                 cli=args.cli,
                 cli_analyzer=args.cli_analyzer,
                 cli_sanity=args.cli_sanity,
+                codex_yolo=args.codex_yolo,
                 log_verbosity=log_verbosity,
                 log_diff_mode=log_diff_mode,
                 verbose_header=verbose_header,
@@ -6146,6 +6158,7 @@ Remote backlog scoping (Jira / Linear / GitHub):
         cli_analyzer=args.cli_analyzer,
         cli_release_eng=args.cli_release_eng,
         cli_sre=args.cli_sre,
+        codex_yolo=args.codex_yolo,
         log_verbosity=log_verbosity,
         log_diff_mode=log_diff_mode,
         verbose_header=verbose_header,

--- a/src/millstone/runtime/parallel.py
+++ b/src/millstone/runtime/parallel.py
@@ -523,6 +523,8 @@ class ParallelOrchestrator:
             cmd.extend(["--cli-sanity", self.orch._cli_sanity])
         if self.orch._cli_analyzer:
             cmd.extend(["--cli-analyzer", self.orch._cli_analyzer])
+        if self.orch._codex_yolo:
+            cmd.append("--codex-yolo")
         if self.orch._custom_prompts_dir is not None:
             cmd.extend(["--prompts-dir", str(self.orch._custom_prompts_dir)])
         return cmd

--- a/tests/test_beads_provider.py
+++ b/tests/test_beads_provider.py
@@ -1,0 +1,350 @@
+"""Tests for the beads-backed artifact providers (subprocess-based)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import millstone.artifact_providers.beads  # noqa: F401 — triggers registration
+from millstone.artifact_providers import (
+    DependencyLinker,
+    OpportunityProvider,
+    ReadyAwareTasklistProvider,
+    TasklistProvider,
+)
+from millstone.artifact_providers.beads import (
+    BeadsCLIError,
+    BeadsOpportunityProvider,
+    BeadsTasklistProvider,
+    _BeadsCLI,
+    _coerce_items,
+)
+from millstone.artifact_providers.registry import (
+    list_opportunity_backends,
+    list_tasklist_backends,
+)
+from millstone.artifacts.models import (
+    DependencyKind,
+    Opportunity,
+    OpportunityStatus,
+    TasklistItem,
+    TaskStatus,
+)
+
+
+class FakeBeadsCLI:
+    """Captures invocations and returns scripted JSON responses by command head."""
+
+    def __init__(self, responses: dict[tuple[str, ...], Any] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.responses = responses or {}
+
+    def _resolve(self, args: list[str]) -> Any:
+        # Match longest prefix in responses table.
+        for length in range(len(args), 0, -1):
+            key = tuple(args[:length])
+            if key in self.responses:
+                value = self.responses[key]
+                return value() if callable(value) else value
+        return ""
+
+    def run(self, args: list[str], *, json_output: bool = False) -> str:
+        self.calls.append(list(args))
+        result = self._resolve(args)
+        if isinstance(result, BeadsCLIError):
+            raise result
+        if json_output:
+            return json.dumps(result) if not isinstance(result, str) else result
+        return result if isinstance(result, str) else json.dumps(result)
+
+    def run_json(self, args: list[str]) -> Any:
+        self.calls.append(list(args))
+        result = self._resolve(args)
+        if isinstance(result, BeadsCLIError):
+            raise result
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_beads_registered():
+    assert "beads" in list_tasklist_backends()
+    assert "beads" in list_opportunity_backends()
+
+
+# ---------------------------------------------------------------------------
+# _BeadsCLI discovery
+# ---------------------------------------------------------------------------
+
+
+def test_cli_discovery_errors_when_bd_missing(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    with pytest.raises(BeadsCLIError, match="not found"):
+        _BeadsCLI()
+
+
+def test_cli_uses_explicit_path(tmp_path):
+    fake_bd = tmp_path / "bd"
+    fake_bd.write_text("#!/bin/sh\necho ok\n")
+    fake_bd.chmod(0o755)
+    cli = _BeadsCLI(bd_path=str(fake_bd))
+    assert cli.bd_path == str(fake_bd)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_items
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload,expected_count",
+    [
+        (None, 0),
+        ([], 0),
+        ([{"id": "bd-1"}, {"id": "bd-2"}], 2),
+        ({"issues": [{"id": "bd-1"}]}, 1),
+        ({"items": [{"id": "bd-1"}, {"id": "bd-2"}]}, 2),
+        ({"id": "bd-9", "title": "x"}, 1),
+        ({"unrelated": "data"}, 0),
+    ],
+)
+def test_coerce_items_normalizes_shapes(payload, expected_count):
+    assert len(_coerce_items(payload)) == expected_count
+
+
+# ---------------------------------------------------------------------------
+# Tasklist provider — read paths
+# ---------------------------------------------------------------------------
+
+
+def test_list_tasks_calls_bd_list_with_label_and_status_filter():
+    fake = FakeBeadsCLI(
+        responses={
+            ("list",): [
+                {"id": "bd-a1", "title": "First", "status": "open"},
+                {"id": "bd-a2", "title": "Second", "status": "in_progress"},
+            ]
+        }
+    )
+    provider = BeadsTasklistProvider(label="millstone-task", cli=fake)
+    items = provider.list_tasks()
+
+    assert [t.task_id for t in items] == ["bd-a1", "bd-a2"]
+    assert items[0].status == TaskStatus.todo
+    assert items[1].status == TaskStatus.in_progress
+
+    args = fake.calls[0]
+    assert args[0] == "list"
+    assert "--label" in args and "millstone-task" in args
+    assert "--status" in args
+
+
+def test_list_ready_tasks_uses_bd_ready():
+    fake = FakeBeadsCLI(
+        responses={("ready",): [{"id": "bd-r1", "title": "Ready", "status": "open"}]}
+    )
+    provider = BeadsTasklistProvider(cli=fake)
+    items = provider.list_ready_tasks()
+
+    assert len(items) == 1
+    assert items[0].task_id == "bd-r1"
+    assert fake.calls[0][0] == "ready"
+
+
+def test_get_task_returns_none_when_bd_show_fails():
+    fake = FakeBeadsCLI(responses={("show", "bd-missing"): BeadsCLIError("not found")})
+    provider = BeadsTasklistProvider(cli=fake)
+    assert provider.get_task("bd-missing") is None
+
+
+def test_get_task_unwraps_single_issue():
+    fake = FakeBeadsCLI(
+        responses={("show", "bd-1"): {"id": "bd-1", "title": "T", "status": "open"}}
+    )
+    provider = BeadsTasklistProvider(cli=fake)
+    item = provider.get_task("bd-1")
+    assert item is not None and item.task_id == "bd-1"
+
+
+# ---------------------------------------------------------------------------
+# Tasklist provider — write paths
+# ---------------------------------------------------------------------------
+
+
+def test_append_tasks_creates_and_assigns_bd_id():
+    fake = FakeBeadsCLI(responses={("create",): {"id": "bd-new1", "title": "T"}})
+    provider = BeadsTasklistProvider(cli=fake)
+    task = TasklistItem(task_id="placeholder", title="Implement X", status=TaskStatus.todo)
+
+    provider.append_tasks([task])
+
+    assert task.task_id == "bd-new1"  # mutated in place
+    create_call = next(c for c in fake.calls if c[0] == "create")
+    assert "Implement X" in create_call
+    assert "-t" in create_call and "task" in create_call
+
+
+def test_append_tasks_links_to_opportunity_when_ref_set():
+    fake = FakeBeadsCLI(responses={("create",): {"id": "bd-new1"}})
+    provider = BeadsTasklistProvider(cli=fake)
+    task = TasklistItem(
+        task_id="placeholder",
+        title="From opp",
+        status=TaskStatus.todo,
+        opportunity_ref="bd-opp9",
+    )
+
+    provider.append_tasks([task])
+
+    dep_calls = [c for c in fake.calls if c[:2] == ["dep", "add"]]
+    assert dep_calls == [
+        ["dep", "add", "bd-new1", "bd-opp9", "--type", "discovered-from"],
+    ]
+
+
+def test_append_tasks_logs_link_failure_but_succeeds(caplog):
+    fake = FakeBeadsCLI(
+        responses={
+            ("create",): {"id": "bd-new1"},
+            ("dep", "add", "bd-new1", "bd-opp9", "--type", "discovered-from"): BeadsCLIError(
+                "no such issue"
+            ),
+        }
+    )
+    provider = BeadsTasklistProvider(cli=fake)
+    task = TasklistItem(
+        task_id="ph",
+        title="t",
+        status=TaskStatus.todo,
+        opportunity_ref="bd-opp9",
+    )
+
+    with caplog.at_level("WARNING"):
+        provider.append_tasks([task])
+
+    assert task.task_id == "bd-new1"
+    assert any("failed to link beads task" in r.message for r in caplog.records)
+
+
+def test_update_task_status_done_uses_close():
+    fake = FakeBeadsCLI()
+    provider = BeadsTasklistProvider(cli=fake)
+    provider.update_task_status("bd-1", TaskStatus.done)
+    assert fake.calls == [["close", "bd-1"]]
+
+
+def test_update_task_status_in_progress_uses_update():
+    fake = FakeBeadsCLI()
+    provider = BeadsTasklistProvider(cli=fake)
+    provider.update_task_status("bd-1", TaskStatus.in_progress)
+    assert fake.calls == [["update", "bd-1", "--status", "in_progress"]]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / restore — scoped rollback
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_then_restore_deletes_only_added_tasks():
+    state = {
+        "current": [
+            {"id": "bd-pre1", "title": "Pre 1", "status": "open"},
+        ]
+    }
+
+    def list_response():
+        return list(state["current"])
+
+    fake = FakeBeadsCLI(responses={("list",): list_response})
+    provider = BeadsTasklistProvider(cli=fake)
+
+    snap = provider.get_snapshot()
+    assert json.loads(snap)["task_ids"] == ["bd-pre1"]
+
+    state["current"].extend(
+        [
+            {"id": "bd-new1", "title": "New 1", "status": "open"},
+            {"id": "bd-new2", "title": "New 2", "status": "open"},
+        ]
+    )
+
+    provider.restore_snapshot(snap)
+    delete_calls = sorted(c for c in fake.calls if c[:1] == ["delete"])
+    assert delete_calls == [["delete", "bd-new1"], ["delete", "bd-new2"]]
+
+
+def test_restore_snapshot_with_invalid_payload_raises():
+    provider = BeadsTasklistProvider(cli=FakeBeadsCLI())
+    with pytest.raises(ValueError, match="invalid beads snapshot"):
+        provider.restore_snapshot("not json")
+
+
+# ---------------------------------------------------------------------------
+# DependencyLinker capability
+# ---------------------------------------------------------------------------
+
+
+def test_link_invokes_bd_dep_add_with_kind():
+    fake = FakeBeadsCLI()
+    provider = BeadsTasklistProvider(cli=fake)
+    provider.link("bd-a", "bd-b", DependencyKind.blocks)
+    assert fake.calls == [["dep", "add", "bd-a", "bd-b", "--type", "blocks"]]
+
+
+def test_provider_satisfies_capability_protocols():
+    provider = BeadsTasklistProvider(cli=FakeBeadsCLI())
+    assert isinstance(provider, TasklistProvider)
+    assert isinstance(provider, ReadyAwareTasklistProvider)
+    assert isinstance(provider, DependencyLinker)
+
+
+# ---------------------------------------------------------------------------
+# Opportunity provider
+# ---------------------------------------------------------------------------
+
+
+def test_opp_list_filters_by_default_label():
+    fake = FakeBeadsCLI(
+        responses={
+            ("list",): [
+                {"id": "bd-o1", "title": "Idea", "status": "open", "description": "do thing"}
+            ]
+        }
+    )
+    provider = BeadsOpportunityProvider(cli=fake)
+    opps = provider.list_opportunities()
+
+    assert len(opps) == 1 and opps[0].opportunity_id == "bd-o1"
+    assert opps[0].status == OpportunityStatus.identified
+    assert "millstone-opportunity" in fake.calls[0]
+
+
+def test_opp_write_assigns_bd_id():
+    fake = FakeBeadsCLI(responses={("create",): {"id": "bd-onew"}})
+    provider = BeadsOpportunityProvider(cli=fake)
+    opp = Opportunity(
+        opportunity_id="placeholder-slug",
+        title="An idea",
+        status=OpportunityStatus.identified,
+        description="Do this thing.",
+    )
+    provider.write_opportunity(opp)
+    assert opp.opportunity_id == "bd-onew"
+
+
+def test_opp_update_status_rejected_uses_close():
+    fake = FakeBeadsCLI()
+    provider = BeadsOpportunityProvider(cli=fake)
+    provider.update_opportunity_status("bd-o1", OpportunityStatus.rejected)
+    assert fake.calls == [["close", "bd-o1"]]
+
+
+def test_opp_satisfies_capability_protocols():
+    provider = BeadsOpportunityProvider(cli=FakeBeadsCLI())
+    assert isinstance(provider, OpportunityProvider)
+    assert isinstance(provider, DependencyLinker)

--- a/tests/test_cli_providers.py
+++ b/tests/test_cli_providers.py
@@ -114,13 +114,19 @@ class TestCodexProvider:
         assert provider.version_command() == ["codex", "--version"]
 
     def test_build_command_basic(self):
-        """Basic command uses stdin sentinel and --yolo."""
+        """Basic command uses stdin sentinel without --yolo by default."""
         provider = CodexProvider()
         cmd = provider.build_command("fix the bug")
         assert cmd[0] == "codex"
         assert "exec" in cmd
         assert "-" in cmd
         assert "fix the bug" not in cmd
+        assert "--yolo" not in cmd
+
+    def test_build_command_with_yolo(self):
+        """CodexProvider can opt into --yolo explicitly."""
+        provider = CodexProvider(yolo=True)
+        cmd = provider.build_command("fix the bug")
         assert "--yolo" in cmd
 
     def test_build_command_with_resume(self):
@@ -169,6 +175,12 @@ class TestProviderRegistry:
         """get_provider('codex') returns CodexProvider."""
         provider = get_provider("codex")
         assert isinstance(provider, CodexProvider)
+
+    def test_get_provider_codex_with_kwargs(self):
+        """get_provider forwards kwargs to provider constructors."""
+        provider = get_provider("codex", yolo=True)
+        assert isinstance(provider, CodexProvider)
+        assert provider.yolo is True
 
     def test_get_provider_unknown_raises(self):
         """get_provider with unknown name raises ValueError."""
@@ -759,6 +771,20 @@ class TestOrchestratorCLIIntegration:
                 builder_provider = orch._get_provider("builder")
                 assert isinstance(default_provider, ClaudeProvider)
                 assert isinstance(builder_provider, CodexProvider)
+            finally:
+                orch.cleanup()
+
+    def test_orchestrator_passes_codex_yolo_to_provider(self):
+        """_get_provider wires codex_yolo into the Codex provider."""
+        from millstone.runtime.orchestrator import Orchestrator
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            orch = Orchestrator(task="test", cli="codex", codex_yolo=True)
+            try:
+                provider = orch._get_provider("builder")
+                assert isinstance(provider, CodexProvider)
+                assert provider.yolo is True
             finally:
                 orch.cleanup()
 

--- a/tests/test_cli_providers.py
+++ b/tests/test_cli_providers.py
@@ -317,6 +317,24 @@ class TestStructuredOutputSchema:
         )
         assert "--output-schema" not in cmd
 
+    def test_codex_resume_with_output_schema_keeps_flags_before_prompt(self, tmp_path):
+        """Codex resume keeps --output-schema before the positional follow-up prompt."""
+        provider = CodexProvider()
+        work_dir = tmp_path / ".millstone"
+        work_dir.mkdir()
+
+        cmd = provider.build_command(
+            "follow-up prompt",
+            resume="session-123",
+            output_schema="review_decision",
+            schema_work_dir=str(work_dir),
+        )
+
+        assert cmd[:4] == ["codex", "exec", "resume", "session-123"]
+        assert "--output-schema" in cmd
+        assert cmd[-1] == "follow-up prompt"
+        assert cmd.index("--output-schema") < cmd.index("follow-up prompt")
+
     def test_claude_output_schema_no_work_dir_needed(self):
         """ClaudeProvider works without schema_work_dir (uses inline JSON)."""
         provider = ClaudeProvider()
@@ -690,6 +708,27 @@ class TestOrchestratorStructuredOutput:
                 agent_call = [c for c in calls if c[0][0][0] == "claude"][-1]
                 cmd = agent_call[0][0]
                 assert "--json-schema" in cmd
+            finally:
+                orch.cleanup()
+
+    def test_run_agent_sanity_with_codex_uses_exec_output_schema(self):
+        """Sanity runs routed to Codex keep --output-schema on `codex exec`."""
+        from millstone.runtime.orchestrator import Orchestrator
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='{"status": "OK"}', stderr="")
+            orch = Orchestrator(task="test", cli="claude", cli_sanity="codex")
+            try:
+                orch.run_agent(
+                    "check this",
+                    role="sanity",
+                    output_schema="sanity_check",
+                )
+                calls = [c for c in mock_run.call_args_list if c[0][0][0] == "codex"]
+                assert calls, "expected a codex subprocess call"
+                cmd = calls[-1][0][0]
+                assert cmd[:3] == ["codex", "exec", "-"]
+                assert "--output-schema" in cmd
             finally:
                 orch.cleanup()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,16 @@ def test_on_eval_regression_config_from_toml(temp_repo):
     assert cfg["on_eval_regression"] == "ignore"
 
 
+def test_codex_yolo_config_from_toml(temp_repo):
+    """codex_yolo should load as a first-class config key."""
+    config_dir = temp_repo / ".millstone"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text("codex_yolo = true\n")
+
+    cfg = load_config(temp_repo)
+    assert cfg["codex_yolo"] is True
+
+
 # ---------------------------------------------------------------------------
 # tasklist_filter schema
 # ---------------------------------------------------------------------------
@@ -218,3 +228,8 @@ def test_help_list_form_examples_present():
 def test_help_shortcut_equivalence_annotation_present():
     """--help output documents that shortcut is equivalent to list form."""
     assert "equivalent to" in _help_output()
+
+
+def test_help_contains_codex_yolo_flag():
+    """--help output documents the Codex yolo opt-in flag."""
+    assert "--codex-yolo" in _help_output()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -769,6 +769,17 @@ class TestParallelOrchestratorPhase2:
         cmd = po._worker_command("task text", temp_repo / ".millstone" / "worktrees" / "task-t1")
         assert "--no-tasklist-edits" in cmd
 
+    def test_worker_command_forwards_codex_yolo(self, temp_repo):
+        orch = Orchestrator(
+            repo_dir=temp_repo,
+            parallel_enabled=True,
+            cli="codex",
+            codex_yolo=True,
+        )
+        po = ParallelOrchestrator(orch)
+        cmd = po._worker_command("task text", temp_repo / ".millstone" / "worktrees" / "task-t1")
+        assert "--codex-yolo" in cmd
+
     def test_concurrent_two_independent_tasks(self, temp_repo):
         base_branch = _git(temp_repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
         (temp_repo / "docs" / "tasklist.md").write_text(


### PR DESCRIPTION
## Summary
- Adds a new `beads` artifact provider (`tasklist_provider` and `opportunity_provider`) backed by direct subprocess calls to the `bd` CLI from https://github.com/gastownhall/beads — no LLM/MCP round-trip.
- Adds optional capability protocols `ReadyAwareTasklistProvider` and `DependencyLinker` (both `@runtime_checkable`), plus a `DependencyKind` enum. Existing providers are unaffected; consumers feature-detect via `isinstance(...)`.
- Tasks appended with an `opportunity_ref` are auto-linked to their source opportunity via `bd dep add ... --type discovered-from`.

## Test plan
- [x] 27 new unit tests in `tests/test_beads_provider.py` cover discovery, read/write paths, status mapping, snapshot rollback, dep linking (success + failure), and protocol conformance
- [x] Full suite green (2119 passed, 7 skipped)
- [x] ruff + mypy + vulture clean

## Notes
- Real-CLI E2E against a live `bd` install is left as a follow-up — `_coerce_items` is defensive about wrapper keys (`issues`/`items`/`results`/`data`), but exact JSON shape may surface a tweak on first use.
- Orchestrator is not yet wired to *consume* `ReadyAwareTasklistProvider`. The protocol exists and beads implements it; picking a call site (likely the inner-loop task picker) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)